### PR TITLE
chore(release): add changeset for obsidian-aware test api

### DIFF
--- a/.changeset/olive-humans-smoke.md
+++ b/.changeset/olive-humans-smoke.md
@@ -1,0 +1,10 @@
+---
+"obsidian-e2e": minor
+---
+
+Add the Obsidian-aware test API refactor introduced in the latest feature work.
+
+This release adds structured `obsidian.dev` helpers, metadata cache helpers,
+note-model sandbox helpers, plugin data patch/reload ergonomics, shared test
+context lifecycle helpers, richer failure artifacts, and new note/frontmatter
+matchers.


### PR DESCRIPTION
Add a Changesets entry for the Obsidian-aware test API work that just landed on `main`.

This marks `obsidian-e2e` for a minor release, which should take the package from `0.4.0` to `0.5.0` once the generated version PR is merged and the publish workflow runs.

The release notes call out the new structured `obsidian.dev` helpers, metadata helpers, sandbox note/frontmatter helpers, plugin patch/reload ergonomics, shared test context lifecycle helpers, richer failure artifacts, and note/frontmatter matchers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/obsidian-e2e/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
