### PR TITLE
feat(fixtures): suite-scoped plugin harness, evalJsonAsync, env resolver

### DIFF
--- a/.changeset/plugin-harness.md
+++ b/.changeset/plugin-harness.md
@@ -1,0 +1,28 @@
+---
+"obsidian-e2e": minor
+---
+
+Add suite-scoped plugin harness, async JSON eval, and an env resolver.
+
+These three additive helpers let plugin repos drop their hand-rolled e2e harness
+boilerplate:
+
+- `obsidian.dev.evalJsonAsync(code)` awaits an async body inside Obsidian and
+  decodes the same `{ ok, value }` envelope as `evalJson`, rethrowing failures as
+  a `DevEvalError` with the remote message and stack.
+- `resolveObsidianEnvOptions()` maps the canonical `OBSIDIAN_E2E_VAULT` /
+  `OBSIDIAN_E2E_VAULT_PATH` / `OBSIDIAN_E2E_OBSIDIAN_HOME` env (with an optional
+  legacy per-plugin prefix fallback) into spreadable client options, injecting
+  `HOME` into `defaultExecOptions.env` per-client without mutating `process.env`.
+  `verifyVaultPath()` refuses to run against the wrong vault.
+- `createPluginHarness()` (from `obsidian-e2e/vitest`) is a suite-scoped fixture
+  that reuses the existing lock, sandbox, artifact, and restore internals: one
+  reload and sandbox per file, optional symlink preflight, per-test diagnostics
+  reset, a `beforeDataRestore` hook before each `data.json` restore, and an
+  ordered error-aggregating teardown. It returns the
+  `(testName) => () => { obsidian, plugin, sandbox }` getter the hand-rolled
+  harnesses already expose.
+
+Also adds an optional `predicate` to `PluginWaitUntilReadyOptions` so
+`plugin.reload({ readyOptions: { predicate } })` can assert readiness beyond the
+ready command. All additive; no existing exports change.

--- a/README.md
+++ b/README.md
@@ -23,9 +23,12 @@ Requirements:
 
 - `obsidian-e2e`
   - low-level client and shared types
+  - `resolveObsidianEnvOptions()` / `verifyVaultPath()`
 - `obsidian-e2e/vitest`
   - `createObsidianTest()`
   - `createPluginTest()`
+  - `createPluginHarness()` (suite-scoped)
+  - `resolveObsidianEnvOptions()` / `verifyVaultPath()`
 - `obsidian-e2e/matchers`
   - optional `expect` matchers for vault and sandbox assertions
 - `obsidian-e2e/runner`
@@ -512,6 +515,63 @@ test("runs against a seeded plugin fixture", async ({ plugin, vault }) => {
 });
 ```
 
+## Suite-Scoped Plugin Harness
+
+`createPluginTest()` is per-test: it reloads the plugin and sandboxes the vault
+for every `test()`. Some suites instead want one reload and one sandbox for the
+whole file, restoring only `data.json` between tests. `createPluginHarness()`
+covers that shape while reusing the same lock, sandbox, artifact, and restore
+internals - so you never hand-roll `beforeAll`/`afterEach`/`afterAll`.
+
+It returns a `(testName) => () => { obsidian, plugin, sandbox }` factory. Call it
+once per suite to register the lifecycle hooks; the returned getter yields the
+live context inside each test:
+
+```ts
+import { createPluginHarness, resolveObsidianEnvOptions } from "obsidian-e2e/vitest";
+import { expect } from "vite-plus/test";
+
+const usePodNotes = createPluginHarness({
+  pluginId: "podnotes",
+  // Canonical OBSIDIAN_E2E_* env, with a legacy per-plugin prefix fallback.
+  ...resolveObsidianEnvOptions({ legacyPrefix: "PODNOTES" }),
+  reload: { readyCommandId: "podnotes:podnotes-show-leaf", timeoutMs: 30_000 },
+  // Extra readiness beyond plugin-loaded + ready command.
+  waitUntilReady: (obsidian) =>
+    obsidian.dev.evalJson<boolean>("Boolean(app.plugins.plugins.podnotes?.api)"),
+  // Runs while the plugin is still enabled, before each data.json restore.
+  beforeDataRestore: (obsidian) =>
+    obsidian.dev.evalJsonAsync(
+      "(async () => { await app.plugins.plugins.podnotes?.saveChain; })()",
+    ),
+  symlinkArtifacts: ["main.js", "manifest.json"],
+  captureOnFailure: true,
+});
+
+const getContext = usePodNotes("podnotes-runtime");
+
+test("keeps the API available after a data reset", async () => {
+  const { obsidian, plugin, sandbox } = getContext();
+  await sandbox.writeNote({ path: "note.md", body: "hi" });
+  await expect(plugin.isEnabled()).resolves.toBe(true);
+});
+```
+
+Lifecycle: `beforeAll` acquires the vault lock and marker, runs the optional
+symlink preflight, creates the sandbox, then reloads the plugin and waits for the
+ready command plus your `waitUntilReady` predicate. `beforeEach` resets
+diagnostics; `afterEach` runs `beforeDataRestore`, restores `data.json`, and
+re-readies the plugin. `afterAll` runs an ordered, error-aggregating teardown
+that always releases the lock.
+
+`resolveObsidianEnvOptions()` maps the canonical `OBSIDIAN_E2E_VAULT`,
+`OBSIDIAN_E2E_VAULT_PATH`, and `OBSIDIAN_E2E_OBSIDIAN_HOME` env (with an optional
+`legacyPrefix` fallback such as `PODNOTES_E2E_VAULT`) into spreadable client
+options. The Obsidian home is injected into `defaultExecOptions.env.HOME`
+per-client, never mutating `process.env`. Pair the returned `expectedVaultPath`
+with `verifyVaultPath()` (or set it on the harness) to refuse running against the
+wrong vault.
+
 ## Failure Artifacts
 
 Both fixture families support opt-in artifact capture:
@@ -717,6 +777,7 @@ to the real `obsidian` CLI:
 - `obsidian.dev.dom({ ... })`
 - `obsidian.dev.eval(code)`
 - `obsidian.dev.evalJson(code)`
+- `obsidian.dev.evalJsonAsync(code)`
 - `obsidian.dev.evalRaw(code)`
 - `obsidian.dev.diagnostics()`
 - `obsidian.dev.resetDiagnostics()`
@@ -838,8 +899,11 @@ test("inspects live UI state", async ({ obsidian }) => {
 
 `obsidian.dev.eval()` remains the low-level escape hatch and preserves the raw
 CLI parsing behavior. Use `obsidian.dev.evalJson()` when you want JSON-safe
-typed results and remote error details, and `obsidian.dev.evalRaw()` when you
-intentionally need the unstructured CLI output. `dev.dom()` and
+typed results and remote error details, `obsidian.dev.evalJsonAsync()` when the
+evaluated code is an async body whose resolved value you need (it awaits the
+promise inside Obsidian before serializing the same `{ ok, value }` envelope,
+rethrowing failures as a `DevEvalError` with the remote message and stack), and
+`obsidian.dev.evalRaw()` when you intentionally need the unstructured CLI output. `dev.dom()` and
 `dev.screenshot()` remain the safer wrappers around the built-in developer CLI
 commands. Screenshot behavior depends on the active desktop environment, so
 start by validating it locally before relying on it in automation.

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -5,7 +5,7 @@ import { createObsidianMetadataHandle } from "../metadata/metadata";
 import { createPluginHandle } from "../plugin/plugin";
 import { executeCommand } from "./transport";
 import { buildDiagnosticsCode, createDevDiagnostics } from "../dev/diagnostics";
-import { parseDevEvalOutput, runEvalJson } from "../dev/eval-json";
+import { parseDevEvalOutput, runEvalJson, runEvalJsonAsync } from "../dev/eval-json";
 import type {
   CommandListOptions,
   CreateObsidianClientOptions,
@@ -123,6 +123,9 @@ export function createObsidianClient(options: CreateObsidianClientOptions): Obsi
     },
     async evalJson<T = unknown>(code: string, execOptions: ExecOptions = {}) {
       return runEvalJson<T>(this, code, execOptions);
+    },
+    async evalJsonAsync<T = unknown>(code: string, execOptions: ExecOptions = {}) {
+      return runEvalJsonAsync<T>(this, code, execOptions);
     },
     async evalRaw(code: string, execOptions: ExecOptions = {}) {
       return client.execText(

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -107,6 +107,7 @@ export type PluginWaitForDataOptions = WaitForOptions;
 
 export interface PluginWaitUntilReadyOptions extends WaitForOptions {
   commandId?: string;
+  predicate?: (client: ObsidianClient) => boolean | Promise<boolean>;
 }
 
 export interface PluginReloadOptions extends ExecOptions {
@@ -232,6 +233,7 @@ export interface ObsidianDevHandle {
   editorText(execOptions?: ExecOptions): Promise<string | null>;
   eval<T = unknown>(code: string, options?: ExecOptions): Promise<T>;
   evalJson<T = unknown>(code: string, options?: ExecOptions): Promise<T>;
+  evalJsonAsync<T = unknown>(code: string, options?: ExecOptions): Promise<T>;
   evalRaw(code: string, options?: ExecOptions): Promise<string>;
   notices(execOptions?: ExecOptions): Promise<DevNoticeEvent[]>;
   resetDiagnostics(execOptions?: ExecOptions): Promise<void>;

--- a/src/dev/eval-json.ts
+++ b/src/dev/eval-json.ts
@@ -71,9 +71,14 @@ export function buildEvalJsonCode(code: string): string {
 }
 
 export function buildEvalJsonAsyncCode(code: string): string {
+  // Indirect `eval` parses its argument as a script, where a top-level `await`
+  // is a SyntaxError. Wrapping the caller's code as the expression body of an
+  // async arrow makes `await` valid while still yielding the expression's value,
+  // so both `await load()` and a plain promise-returning expression work.
+  const asyncExpression = `(async()=>(${code}))()`;
   return [
     "(async()=>{",
-    `const __obsidianE2ECode=${JSON.stringify(code)};`,
+    `const __obsidianE2ECode=${JSON.stringify(asyncExpression)};`,
     EVAL_JSON_SERIALIZER,
     "try{",
     "return JSON.stringify({ok:true,value:__obsidianE2ESerialize(await (0,eval)(__obsidianE2ECode))});",

--- a/src/dev/eval-json.ts
+++ b/src/dev/eval-json.ts
@@ -17,6 +17,29 @@ interface UndefinedSentinel {
   __obsidianE2EType: "undefined";
 }
 
+// The serializer and the failure branch are shared verbatim by the synchronous
+// and asynchronous builders so both produce the same {ok,value}|{ok:false,error}
+// envelope, decoded by the single parseEvalJsonEnvelope path below.
+const EVAL_JSON_SERIALIZER = [
+  "const __obsidianE2ESerialize=(value,path='$')=>{",
+  "if(value===null){return null;}",
+  "if(value===undefined){return {__obsidianE2EType:'undefined'};}",
+  "const valueType=typeof value;",
+  "if(valueType==='string'||valueType==='boolean'){return value;}",
+  "if(valueType==='number'){if(!Number.isFinite(value)){throw new Error(`Cannot serialize non-finite number at ${path}.`);}return value;}",
+  "if(valueType==='bigint'||valueType==='function'||valueType==='symbol'){throw new Error(`Cannot serialize ${valueType} at ${path}.`);}",
+  "if(Array.isArray(value)){return value.map((item,index)=>__obsidianE2ESerialize(item,`${path}[${index}]`));}",
+  "const prototype=Object.getPrototypeOf(value);",
+  "if(prototype!==Object.prototype&&prototype!==null){throw new Error(`Cannot serialize non-plain object at ${path}.`);}",
+  "const next={};",
+  "for(const [key,entry] of Object.entries(value)){next[key]=__obsidianE2ESerialize(entry,`${path}.${key}`);}",
+  "return next;",
+  "};",
+].join("");
+
+const EVAL_JSON_FAILURE_BRANCH =
+  "return JSON.stringify({ok:false,error:{message:error instanceof Error?error.message:String(error),name:error instanceof Error?error.name:'Error',stack:error instanceof Error?error.stack:undefined}});";
+
 export async function runEvalJson<T>(
   dev: Pick<ObsidianDevHandle, "evalRaw">,
   code: string,
@@ -25,28 +48,37 @@ export async function runEvalJson<T>(
   return parseEvalJsonEnvelope<T>(await dev.evalRaw(buildEvalJsonCode(code), execOptions));
 }
 
+export async function runEvalJsonAsync<T>(
+  dev: Pick<ObsidianDevHandle, "evalRaw">,
+  code: string,
+  execOptions: ExecOptions = {},
+): Promise<T> {
+  return parseEvalJsonEnvelope<T>(await dev.evalRaw(buildEvalJsonAsyncCode(code), execOptions));
+}
+
 export function buildEvalJsonCode(code: string): string {
   return [
     "(()=>{",
     `const __obsidianE2ECode=${JSON.stringify(code)};`,
-    "const __obsidianE2ESerialize=(value,path='$')=>{",
-    "if(value===null){return null;}",
-    "if(value===undefined){return {__obsidianE2EType:'undefined'};}",
-    "const valueType=typeof value;",
-    "if(valueType==='string'||valueType==='boolean'){return value;}",
-    "if(valueType==='number'){if(!Number.isFinite(value)){throw new Error(`Cannot serialize non-finite number at ${path}.`);}return value;}",
-    "if(valueType==='bigint'||valueType==='function'||valueType==='symbol'){throw new Error(`Cannot serialize ${valueType} at ${path}.`);}",
-    "if(Array.isArray(value)){return value.map((item,index)=>__obsidianE2ESerialize(item,`${path}[${index}]`));}",
-    "const prototype=Object.getPrototypeOf(value);",
-    "if(prototype!==Object.prototype&&prototype!==null){throw new Error(`Cannot serialize non-plain object at ${path}.`);}",
-    "const next={};",
-    "for(const [key,entry] of Object.entries(value)){next[key]=__obsidianE2ESerialize(entry,`${path}.${key}`);}",
-    "return next;",
-    "};",
+    EVAL_JSON_SERIALIZER,
     "try{",
     "return JSON.stringify({ok:true,value:__obsidianE2ESerialize((0,eval)(__obsidianE2ECode))});",
     "}catch(error){",
-    "return JSON.stringify({ok:false,error:{message:error instanceof Error?error.message:String(error),name:error instanceof Error?error.name:'Error',stack:error instanceof Error?error.stack:undefined}});",
+    EVAL_JSON_FAILURE_BRANCH,
+    "}",
+    "})()",
+  ].join("");
+}
+
+export function buildEvalJsonAsyncCode(code: string): string {
+  return [
+    "(async()=>{",
+    `const __obsidianE2ECode=${JSON.stringify(code)};`,
+    EVAL_JSON_SERIALIZER,
+    "try{",
+    "return JSON.stringify({ok:true,value:__obsidianE2ESerialize(await (0,eval)(__obsidianE2ECode))});",
+    "}catch(error){",
+    EVAL_JSON_FAILURE_BRANCH,
     "}",
     "})()",
   ].join("");

--- a/src/env/resolve-env.ts
+++ b/src/env/resolve-env.ts
@@ -1,0 +1,111 @@
+import path from "node:path";
+
+import type { CreateObsidianClientOptions } from "../core/types";
+
+const CANONICAL_VAULT = "OBSIDIAN_E2E_VAULT";
+const CANONICAL_VAULT_PATH = "OBSIDIAN_E2E_VAULT_PATH";
+const CANONICAL_OBSIDIAN_HOME = "OBSIDIAN_E2E_OBSIDIAN_HOME";
+const CANONICAL_BIN = "OBSIDIAN_BIN";
+const DEFAULT_VAULT = "dev";
+
+export interface ResolveObsidianEnvOptions {
+  /** Fallback binary name when `OBSIDIAN_BIN` is unset. */
+  bin?: string;
+  /** Environment to read from. Defaults to `process.env`; never mutated. */
+  env?: NodeJS.ProcessEnv;
+  /**
+   * Legacy per-plugin env prefix (e.g. `"METAEDIT"`) whose `*_E2E_VAULT`,
+   * `*_E2E_VAULT_PATH`, and `*_E2E_OBSIDIAN_HOME` variants are consulted when
+   * the canonical `OBSIDIAN_E2E_*` names are absent.
+   */
+  legacyPrefix?: string;
+  /** Fallback vault name when no canonical or legacy vault env is set. */
+  vault?: string;
+}
+
+export interface ResolvedObsidianEnvOptions extends Partial<CreateObsidianClientOptions> {
+  vault: string;
+  /**
+   * The vault path the CLI is expected to resolve to, from
+   * `OBSIDIAN_E2E_VAULT_PATH` (or the legacy alias). Pass to `verifyVaultPath`
+   * once the client reports its actual `vaultPath()`.
+   */
+  expectedVaultPath?: string;
+}
+
+/**
+ * Resolve canonical `OBSIDIAN_E2E_*` env into spreadable client options.
+ *
+ * The Obsidian home (`OBSIDIAN_E2E_OBSIDIAN_HOME`) is injected into
+ * `defaultExecOptions.env.HOME` per-client so the CLI hits the intended socket
+ * without ever mutating `process.env`.
+ */
+export function resolveObsidianEnvOptions(
+  options: ResolveObsidianEnvOptions = {},
+): ResolvedObsidianEnvOptions {
+  const env = options.env ?? process.env;
+  const legacy = (suffix: string): string | undefined =>
+    options.legacyPrefix ? env[`${options.legacyPrefix}_${suffix}`] : undefined;
+
+  const vault = env[CANONICAL_VAULT] ?? legacy("E2E_VAULT") ?? options.vault ?? DEFAULT_VAULT;
+  const expectedVaultPath = env[CANONICAL_VAULT_PATH] ?? legacy("E2E_VAULT_PATH");
+  const obsidianHome = env[CANONICAL_OBSIDIAN_HOME] ?? legacy("E2E_OBSIDIAN_HOME");
+  const bin = env[CANONICAL_BIN] ?? options.bin;
+
+  const resolved: ResolvedObsidianEnvOptions = { vault };
+
+  if (bin) {
+    resolved.bin = bin;
+  }
+
+  if (expectedVaultPath) {
+    resolved.expectedVaultPath = expectedVaultPath;
+  }
+
+  if (obsidianHome) {
+    resolved.defaultExecOptions = {
+      env: { ...env, HOME: obsidianHome },
+    };
+  }
+
+  return resolved;
+}
+
+export interface VerifyVaultPathOptions {
+  actualVaultPath: string;
+  expectedVaultPath?: string;
+  vaultName?: string;
+}
+
+/**
+ * Assert the CLI-resolved vault path matches the expected one, throwing a clear
+ * error on mismatch so a misconfigured run never touches the wrong vault.
+ * Returns the resolved actual path when it matches (or when no expectation set).
+ */
+export function verifyVaultPath({
+  actualVaultPath,
+  expectedVaultPath,
+  vaultName,
+}: VerifyVaultPathOptions): string {
+  const resolvedActual = path.resolve(actualVaultPath);
+
+  if (!expectedVaultPath) {
+    return resolvedActual;
+  }
+
+  const resolvedExpected = path.resolve(expectedVaultPath);
+
+  if (resolvedActual !== resolvedExpected) {
+    throw new Error(
+      [
+        vaultName
+          ? `Obsidian CLI resolved E2E vault "${vaultName}" to ${resolvedActual}.`
+          : `Obsidian CLI resolved the E2E vault to ${resolvedActual}.`,
+        `Expected ${resolvedExpected}.`,
+        "Refusing to run E2E tests against the wrong vault.",
+      ].join(" "),
+    );
+  }
+
+  return resolvedActual;
+}

--- a/src/fixtures/plugin-harness.ts
+++ b/src/fixtures/plugin-harness.ts
@@ -1,0 +1,291 @@
+import { readlink } from "node:fs/promises";
+import path from "node:path";
+
+import { afterAll, afterEach, beforeAll, beforeEach } from "vite-plus/test";
+import type { TestContext as VitestTestContext } from "vite-plus/test";
+
+import type { FailureArtifactTask } from "../artifacts/failure-artifacts";
+import type {
+  ObsidianClient,
+  PluginHandle,
+  PluginToggleOptions,
+  PluginWaitUntilReadyOptions,
+  SandboxApi,
+} from "../core/types";
+import { verifyVaultPath } from "../env/resolve-env";
+import { createInternalTestContext } from "./test-context";
+import type { CreateObsidianTestOptions, TestContext } from "./types";
+
+const DEFAULT_SETUP_TIMEOUT_MS = 90_000;
+const DEFAULT_TEARDOWN_TIMEOUT_MS = 30_000;
+const DEFAULT_RELOAD_TIMEOUT_MS = 30_000;
+const DEFAULT_READY_INTERVAL_MS = 200;
+const DEFAULT_LOCK_TIMEOUT_MS = 60_000;
+
+export interface PluginHarnessContext {
+  obsidian: ObsidianClient;
+  plugin: PluginHandle;
+  sandbox: SandboxApi;
+}
+
+export interface PluginHarnessReloadOptions {
+  intervalMs?: number;
+  readyCommandId?: string;
+  timeoutMs?: number;
+}
+
+export interface CreatePluginHarnessOptions extends CreateObsidianTestOptions {
+  /**
+   * Runs before every `plugin.restoreData()` (per-test and at teardown), while
+   * the plugin is still enabled - the seam for plugin-specific flushing or view
+   * detaching that must complete before the settings file is rolled back.
+   */
+  beforeDataRestore?: (obsidian: ObsidianClient) => void | Promise<void>;
+  /** Expected CLI-resolved vault path; a mismatch fails the suite in setup. */
+  expectedVaultPath?: string;
+  pluginFilter?: PluginToggleOptions["filter"];
+  pluginId: string;
+  reload?: PluginHarnessReloadOptions;
+  /** `beforeAll` timeout in ms. Defaults to 90000. */
+  setupTimeoutMs?: number;
+  /**
+   * Optional dev-vault symlink preflight: asserts each artifact under
+   * `<vault>/.obsidian/plugins/<pluginId>/` is a symlink into `symlinkRepoRoot`.
+   */
+  symlinkArtifacts?: string[];
+  /** Root the symlinked artifacts must point at. Defaults to `process.cwd()`. */
+  symlinkRepoRoot?: string;
+  /** `afterAll` timeout in ms. Defaults to 30000. */
+  teardownTimeoutMs?: number;
+  /** Extra readiness predicate beyond plugin-loaded and the ready command. */
+  waitUntilReady?: (obsidian: ObsidianClient) => boolean | Promise<boolean>;
+}
+
+export interface PluginHarnessSession {
+  captureFailure(task: FailureArtifactTask): Promise<void>;
+  getContext(): PluginHarnessContext;
+  resetDiagnostics(): Promise<void>;
+  restoreData(): Promise<void>;
+  setup(): Promise<void>;
+  teardown(): Promise<void>;
+}
+
+/**
+ * Suite-scoped harness for a single plugin: one vault lock, one sandbox, one
+ * reload for the whole file, with per-test diagnostics reset and data restore.
+ *
+ * `createPluginHarness(options)` returns a `(testName) => () => context` factory
+ * matching the getter shape the hand-rolled per-repo harnesses already expose,
+ * so consumer test bodies migrate untouched.
+ */
+export function createPluginHarness(
+  options: CreatePluginHarnessOptions,
+): (testName: string) => () => PluginHarnessContext {
+  const setupTimeoutMs = options.setupTimeoutMs ?? DEFAULT_SETUP_TIMEOUT_MS;
+  const teardownTimeoutMs = options.teardownTimeoutMs ?? DEFAULT_TEARDOWN_TIMEOUT_MS;
+
+  return (testName: string): (() => PluginHarnessContext) => {
+    const session = createPluginHarnessSession(options, testName);
+
+    beforeAll(() => session.setup(), setupTimeoutMs);
+
+    beforeEach((ctx: VitestTestContext) => {
+      ctx.onTestFailed(async () => {
+        await session.captureFailure({ id: ctx.task.id, name: ctx.task.name }).catch((error) => {
+          console.warn(`Plugin "${options.pluginId}" harness artifact capture failed`, error);
+        });
+      });
+    });
+
+    beforeEach(() => session.resetDiagnostics());
+
+    afterEach(() => session.restoreData());
+
+    afterAll(() => session.teardown(), teardownTimeoutMs);
+
+    return () => session.getContext();
+  };
+}
+
+/**
+ * Lifecycle for one harness instance without registering any vitest hooks - the
+ * seam `createPluginHarness` drives and tests exercise directly.
+ */
+export function createPluginHarnessSession(
+  options: CreatePluginHarnessOptions,
+  testName: string,
+): PluginHarnessSession {
+  const {
+    beforeDataRestore,
+    expectedVaultPath,
+    pluginFilter,
+    pluginId,
+    reload,
+    setupTimeoutMs: _setupTimeoutMs,
+    symlinkArtifacts,
+    symlinkRepoRoot,
+    teardownTimeoutMs: _teardownTimeoutMs,
+    waitUntilReady,
+    ...testOptions
+  } = options;
+
+  const readyWaitOptions: PluginWaitUntilReadyOptions = {
+    commandId: reload?.readyCommandId,
+    intervalMs: reload?.intervalMs ?? DEFAULT_READY_INTERVAL_MS,
+    predicate: waitUntilReady,
+    timeoutMs: reload?.timeoutMs ?? DEFAULT_RELOAD_TIMEOUT_MS,
+  };
+
+  const needsPreflight = Boolean(expectedVaultPath || symlinkArtifacts?.length);
+
+  let context: TestContext | undefined;
+  let plugin: PluginHandle | undefined;
+  let ready = false;
+
+  async function runPreflight(obsidian: ObsidianClient): Promise<void> {
+    const vaultPath = await obsidian.vaultPath();
+
+    if (expectedVaultPath) {
+      verifyVaultPath({ actualVaultPath: vaultPath, expectedVaultPath, vaultName: options.vault });
+    }
+
+    if (symlinkArtifacts?.length) {
+      await assertPluginArtifactSymlinks({
+        artifacts: symlinkArtifacts,
+        pluginId,
+        repoRoot: symlinkRepoRoot ?? process.cwd(),
+        vaultPath,
+      });
+    }
+  }
+
+  async function restorePluginData(): Promise<void> {
+    if (!context || !plugin) {
+      return;
+    }
+
+    await beforeDataRestore?.(context.obsidian);
+    await plugin.disable({ filter: pluginFilter });
+    await plugin.restoreData();
+    await plugin.enable({ filter: pluginFilter });
+    await plugin.waitUntilReady(readyWaitOptions);
+  }
+
+  return {
+    async captureFailure(task: FailureArtifactTask): Promise<void> {
+      if (!context) {
+        return;
+      }
+
+      await context.captureFailureArtifacts(task);
+    },
+    getContext(): PluginHarnessContext {
+      if (!ready || !context || !plugin) {
+        throw new Error(`Plugin "${pluginId}" harness is not initialized.`);
+      }
+
+      return { obsidian: context.obsidian, plugin, sandbox: context.sandbox };
+    },
+    async resetDiagnostics(): Promise<void> {
+      await context?.resetDiagnostics();
+    },
+    restoreData: restorePluginData,
+    async setup(): Promise<void> {
+      context = await createInternalTestContext({
+        ...testOptions,
+        beforeSandbox: needsPreflight ? runPreflight : undefined,
+        sharedVaultLock: testOptions.sharedVaultLock ?? {
+          onBusy: "wait",
+          timeoutMs: DEFAULT_LOCK_TIMEOUT_MS,
+        },
+        testName,
+      });
+
+      plugin = await context.plugin(pluginId, { filter: pluginFilter });
+
+      await plugin.reload({
+        readyOptions: readyWaitOptions,
+        waitUntilReady: true,
+      });
+
+      ready = true;
+    },
+    async teardown(): Promise<void> {
+      const errors: unknown[] = [];
+
+      await runTeardown(pluginId, "restore plugin data", errors, restorePluginData);
+      await runTeardown(pluginId, "clean up harness context", errors, () => context?.cleanup());
+
+      ready = false;
+
+      if (errors.length === 1) {
+        throw errors[0];
+      }
+
+      if (errors.length > 1) {
+        throw new AggregateError(errors, `Plugin "${pluginId}" harness teardown failed.`);
+      }
+    },
+  };
+}
+
+interface AssertPluginArtifactSymlinksOptions {
+  artifacts: string[];
+  pluginId: string;
+  repoRoot: string;
+  vaultPath: string;
+}
+
+async function assertPluginArtifactSymlinks({
+  artifacts,
+  pluginId,
+  repoRoot,
+  vaultPath,
+}: AssertPluginArtifactSymlinksOptions): Promise<void> {
+  const pluginDir = path.join(vaultPath, ".obsidian", "plugins", pluginId);
+
+  for (const fileName of artifacts) {
+    const linkPath = path.join(pluginDir, fileName);
+    const expected = path.join(repoRoot, fileName);
+    let target: string;
+
+    try {
+      target = await readlink(linkPath);
+    } catch (error) {
+      throw new Error(
+        [
+          `Plugin "${pluginId}" E2E preflight failed.`,
+          `Expected ${linkPath} to be a symlink to ${expected}.`,
+          `Could not read symlink: ${error instanceof Error ? error.message : String(error)}`,
+        ].join(" "),
+      );
+    }
+
+    const resolvedTarget = path.resolve(path.dirname(linkPath), target);
+
+    if (resolvedTarget !== expected) {
+      throw new Error(
+        [
+          `Plugin "${pluginId}" E2E preflight failed.`,
+          `Expected ${linkPath} to point at ${expected}.`,
+          `It currently points at ${resolvedTarget}.`,
+          "Repoint the dev vault plugin symlink intentionally before running the E2E suite.",
+        ].join(" "),
+      );
+    }
+  }
+}
+
+async function runTeardown(
+  pluginId: string,
+  label: string,
+  errors: unknown[],
+  step: () => unknown,
+): Promise<void> {
+  try {
+    await step();
+  } catch (error) {
+    errors.push(error);
+    console.warn(`Plugin "${pluginId}" harness teardown failed during ${label}`, error);
+  }
+}

--- a/src/fixtures/test-context.ts
+++ b/src/fixtures/test-context.ts
@@ -10,6 +10,7 @@ import { acquireVaultRunLock, clearVaultRunLockMarker, type VaultRunLock } from 
 import type { CreateObsidianTestOptions, PluginSessionOptions, TestContext } from "./types";
 
 interface CreateInternalTestContextOptions extends CreateObsidianTestOptions {
+  beforeSandbox?: (obsidian: ObsidianClient) => Promise<void> | void;
   createVault?: (obsidian: ObsidianClient) => Promise<VaultApi> | VaultApi;
   testName?: string;
   vaultLock?: VaultRunLock | null;
@@ -60,6 +61,8 @@ export async function createInternalTestContext(
     }
 
     await obsidian.dev.resetDiagnostics().catch(() => {});
+
+    await options.beforeSandbox?.(obsidian);
 
     const vault = await vaultFactory(obsidian);
     sandbox = await createSandboxApi({

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,12 @@ export {
   DEFAULT_FAILURE_ARTIFACTS_DIR,
 } from "./artifacts/failure-artifacts";
 export { createTestContext, withVaultSandbox } from "./fixtures/test-context";
+export { resolveObsidianEnvOptions, verifyVaultPath } from "./env/resolve-env";
+export type {
+  ResolveObsidianEnvOptions,
+  ResolvedObsidianEnvOptions,
+  VerifyVaultPathOptions,
+} from "./env/resolve-env";
 export {
   acquireVaultRunLock,
   clearVaultRunLockMarker,

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -177,8 +177,12 @@ export function createPluginHandle(client: ObsidianClient, id: string): PluginHa
             return false;
           }
 
-          if (options.commandId) {
-            return await client.command(options.commandId).exists();
+          if (options.commandId && !(await client.command(options.commandId).exists())) {
+            return false;
+          }
+
+          if (options.predicate && !(await options.predicate(client))) {
+            return false;
           }
 
           return true;

--- a/src/vitest.ts
+++ b/src/vitest.ts
@@ -1,11 +1,23 @@
 export { createObsidianTest } from "./fixtures/create-obsidian-test";
 export { createPluginTest } from "./fixtures/create-plugin-test";
+export { createPluginHarness } from "./fixtures/plugin-harness";
 export {
   acquireVaultRunLock,
   clearVaultRunLockMarker,
   inspectVaultRunLock,
   readVaultRunLockMarker,
 } from "./fixtures/vault-lock";
+export { resolveObsidianEnvOptions, verifyVaultPath } from "./env/resolve-env";
+export type {
+  ResolveObsidianEnvOptions,
+  ResolvedObsidianEnvOptions,
+  VerifyVaultPathOptions,
+} from "./env/resolve-env";
+export type {
+  CreatePluginHarnessOptions,
+  PluginHarnessContext,
+  PluginHarnessReloadOptions,
+} from "./fixtures/plugin-harness";
 export type {
   CreatePluginTestOptions,
   CreateObsidianTestOptions,

--- a/tests/dev/eval-json-async.test.ts
+++ b/tests/dev/eval-json-async.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { createObsidianClient } from "../../src/core/client";
+import { DevEvalError } from "../../src/core/errors";
+import { buildEvalJsonAsyncCode, runEvalJsonAsync } from "../../src/dev/eval-json";
+import { createExecResult } from "../helpers/create-exec-result";
+import type { CommandTransport, ObsidianDevHandle } from "../../src/core/types";
+
+function stubDev(
+  evalRaw: (code: string) => Promise<string> | string,
+): Pick<ObsidianDevHandle, "evalRaw"> {
+  return {
+    async evalRaw(code) {
+      return evalRaw(code);
+    },
+  };
+}
+
+describe("buildEvalJsonAsyncCode", () => {
+  it("emits an async IIFE that awaits the evaluated code", () => {
+    const code = buildEvalJsonAsyncCode("app.foo()");
+
+    expect(code.startsWith("(async()=>{")).toBe(true);
+    expect(code).toContain("await (0,eval)(__obsidianE2ECode)");
+    // Reuses the shared serializer/decoder envelope.
+    expect(code).toContain("__obsidianE2ESerialize");
+    expect(code).toContain("JSON.stringify({ok:true,value:");
+  });
+});
+
+describe("runEvalJsonAsync", () => {
+  it("resolves the awaited value from a success envelope", async () => {
+    const dev = stubDev(() => JSON.stringify({ ok: true, value: { count: 2, items: [1, 2] } }));
+
+    await expect(runEvalJsonAsync(dev, "await load()")).resolves.toEqual({
+      count: 2,
+      items: [1, 2],
+    });
+  });
+
+  it("decodes the undefined sentinel", async () => {
+    const dev = stubDev(() =>
+      JSON.stringify({ ok: true, value: { done: { __obsidianE2EType: "undefined" } } }),
+    );
+
+    await expect(runEvalJsonAsync(dev, "await noop()")).resolves.toEqual({ done: undefined });
+  });
+
+  it("surfaces a thrown error with message and remote stack", async () => {
+    const dev = stubDev(() =>
+      JSON.stringify({
+        ok: false,
+        error: { message: "boom", name: "TypeError", stack: "TypeError: boom\n    at eval" },
+      }),
+    );
+
+    const error = await runEvalJsonAsync(dev, "await fail()").catch((thrown) => thrown);
+
+    expect(error).toBeInstanceOf(DevEvalError);
+    expect((error as DevEvalError).message).toBe("Failed to evaluate Obsidian code: boom");
+    expect((error as DevEvalError).remote.stack).toBe("TypeError: boom\n    at eval");
+    expect((error as DevEvalError).stack).toContain("TypeError: boom\n    at eval");
+  });
+});
+
+describe("obsidian.dev.evalJsonAsync", () => {
+  it("passes the async builder output through evalRaw and decodes the envelope", async () => {
+    const evalCodes: string[] = [];
+    const transport: CommandTransport = async (request) => {
+      if (request.argv[0] === "--help") {
+        return createExecResult(request.bin, request.argv, "usage\n");
+      }
+
+      const [, command, ...rest] = request.argv;
+      const args = Object.fromEntries(
+        rest
+          .filter((entry) => entry.includes("="))
+          .map((entry) => {
+            const [key, ...value] = entry.split("=");
+            return [key, value.join("=")];
+          }),
+      );
+
+      if (command === "vault" && args.info === "path") {
+        return createExecResult(request.bin, request.argv, "/tmp/vault\n");
+      }
+
+      if (command === "eval") {
+        evalCodes.push(args.code ?? "");
+        return createExecResult(
+          request.bin,
+          request.argv,
+          `${JSON.stringify({ ok: true, value: "ready" })}\n`,
+        );
+      }
+
+      throw new Error(`Unhandled transport request: ${request.argv.join(" ")}`);
+    };
+
+    const obsidian = createObsidianClient({ transport, vault: "dev" });
+
+    await expect(
+      obsidian.dev.evalJsonAsync<string>("await Promise.resolve('ready')"),
+    ).resolves.toBe("ready");
+    expect(evalCodes).toHaveLength(1);
+    expect(evalCodes[0]).toContain("await (0,eval)(__obsidianE2ECode)");
+  });
+});

--- a/tests/dev/eval-json-async.test.ts
+++ b/tests/dev/eval-json-async.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vite-plus/test";
 
 import { createObsidianClient } from "../../src/core/client";
 import { DevEvalError } from "../../src/core/errors";
-import { buildEvalJsonAsyncCode, runEvalJsonAsync } from "../../src/dev/eval-json";
+import {
+  buildEvalJsonAsyncCode,
+  parseEvalJsonEnvelope,
+  runEvalJsonAsync,
+} from "../../src/dev/eval-json";
 import { createExecResult } from "../helpers/create-exec-result";
 import type { CommandTransport, ObsidianDevHandle } from "../../src/core/types";
 
@@ -25,6 +29,46 @@ describe("buildEvalJsonAsyncCode", () => {
     // Reuses the shared serializer/decoder envelope.
     expect(code).toContain("__obsidianE2ESerialize");
     expect(code).toContain("JSON.stringify({ok:true,value:");
+  });
+
+  it("wraps the caller code so a top-level await parses", () => {
+    // Indirect eval treats its argument as a script, where a bare `await` would
+    // be a SyntaxError; the wrapper turns it into an async arrow expression body.
+    const code = buildEvalJsonAsyncCode("await load()");
+
+    expect(code).toContain(JSON.stringify("(async()=>(await load()))()"));
+  });
+});
+
+// Exercises the generated code in a real JS engine (the stubbed transport tests
+// above never execute it) so the top-level-await path cannot regress silently.
+describe("buildEvalJsonAsyncCode executed", () => {
+  const evalGenerated = async <T>(userCode: string): Promise<T> => {
+    const raw = await (0, eval)(buildEvalJsonAsyncCode(userCode));
+    return parseEvalJsonEnvelope<T>(raw);
+  };
+
+  it("runs a top-level-await body and returns the resolved value", async () => {
+    await expect(evalGenerated("await Promise.resolve({ count: 2 })")).resolves.toEqual({
+      count: 2,
+    });
+  });
+
+  it("runs a promise-returning expression", async () => {
+    await expect(evalGenerated("Promise.resolve('ready')")).resolves.toBe("ready");
+  });
+
+  it("runs an async IIFE expression", async () => {
+    await expect(evalGenerated("(async () => 'done')()")).resolves.toBe("done");
+  });
+
+  it("surfaces a rejected promise as a DevEvalError", async () => {
+    const error = await evalGenerated("Promise.reject(new TypeError('nope'))").catch(
+      (thrown) => thrown,
+    );
+
+    expect(error).toBeInstanceOf(DevEvalError);
+    expect((error as DevEvalError).message).toBe("Failed to evaluate Obsidian code: nope");
   });
 });
 

--- a/tests/env/resolve-env.test.ts
+++ b/tests/env/resolve-env.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveObsidianEnvOptions, verifyVaultPath } from "../../src/env/resolve-env";
+
+describe("resolveObsidianEnvOptions", () => {
+  it("maps the canonical OBSIDIAN_E2E_* names", () => {
+    const env = {
+      OBSIDIAN_BIN: "obsidian-beta",
+      OBSIDIAN_E2E_OBSIDIAN_HOME: "/home/e2e",
+      OBSIDIAN_E2E_VAULT: "e2e",
+      OBSIDIAN_E2E_VAULT_PATH: "/vaults/e2e",
+      UNRELATED: "keep",
+    } as NodeJS.ProcessEnv;
+
+    const resolved = resolveObsidianEnvOptions({ env });
+
+    expect(resolved.vault).toBe("e2e");
+    expect(resolved.bin).toBe("obsidian-beta");
+    expect(resolved.expectedVaultPath).toBe("/vaults/e2e");
+    expect(resolved.defaultExecOptions?.env?.HOME).toBe("/home/e2e");
+    // Non-HOME env is carried through so the child still inherits PATH etc.
+    expect(resolved.defaultExecOptions?.env?.UNRELATED).toBe("keep");
+  });
+
+  it("falls back to the legacy prefix when canonical names are absent", () => {
+    const env = {
+      METAEDIT_E2E_OBSIDIAN_HOME: "/home/legacy",
+      METAEDIT_E2E_VAULT: "legacy",
+      METAEDIT_E2E_VAULT_PATH: "/vaults/legacy",
+    } as NodeJS.ProcessEnv;
+
+    const resolved = resolveObsidianEnvOptions({ env, legacyPrefix: "METAEDIT" });
+
+    expect(resolved.vault).toBe("legacy");
+    expect(resolved.expectedVaultPath).toBe("/vaults/legacy");
+    expect(resolved.defaultExecOptions?.env?.HOME).toBe("/home/legacy");
+  });
+
+  it("prefers canonical names over the legacy prefix", () => {
+    const env = {
+      METAEDIT_E2E_VAULT: "legacy",
+      OBSIDIAN_E2E_VAULT: "canonical",
+    } as NodeJS.ProcessEnv;
+
+    expect(resolveObsidianEnvOptions({ env, legacyPrefix: "METAEDIT" }).vault).toBe("canonical");
+  });
+
+  it("injects HOME without mutating the source env", () => {
+    const env = {
+      OBSIDIAN_E2E_OBSIDIAN_HOME: "/home/e2e",
+      HOME: "/home/original",
+    } as NodeJS.ProcessEnv;
+
+    const resolved = resolveObsidianEnvOptions({ env });
+
+    expect(resolved.defaultExecOptions?.env?.HOME).toBe("/home/e2e");
+    expect(env.HOME).toBe("/home/original");
+    expect(resolved.defaultExecOptions?.env).not.toBe(env);
+  });
+
+  it("passes through with defaults when no env is set", () => {
+    const resolved = resolveObsidianEnvOptions({ env: {} as NodeJS.ProcessEnv });
+
+    expect(resolved.vault).toBe("dev");
+    expect(resolved.bin).toBeUndefined();
+    expect(resolved.expectedVaultPath).toBeUndefined();
+    expect(resolved.defaultExecOptions).toBeUndefined();
+  });
+
+  it("honors the fallback vault and bin", () => {
+    const resolved = resolveObsidianEnvOptions({
+      bin: "custom",
+      env: {} as NodeJS.ProcessEnv,
+      vault: "scratch",
+    });
+
+    expect(resolved.vault).toBe("scratch");
+    expect(resolved.bin).toBe("custom");
+  });
+});
+
+describe("verifyVaultPath", () => {
+  it("returns the resolved path when it matches the expectation", () => {
+    expect(
+      verifyVaultPath({ actualVaultPath: "/vaults/e2e", expectedVaultPath: "/vaults/e2e" }),
+    ).toBe("/vaults/e2e");
+  });
+
+  it("returns the resolved path when no expectation is set", () => {
+    expect(verifyVaultPath({ actualVaultPath: "/vaults/e2e" })).toBe("/vaults/e2e");
+  });
+
+  it("throws a clear error on mismatch", () => {
+    expect(() =>
+      verifyVaultPath({
+        actualVaultPath: "/vaults/wrong",
+        expectedVaultPath: "/vaults/e2e",
+        vaultName: "e2e",
+      }),
+    ).toThrow(/resolved E2E vault "e2e" to \/vaults\/wrong.*Expected \/vaults\/e2e/su);
+  });
+});

--- a/tests/fixtures/plugin-harness.test.ts
+++ b/tests/fixtures/plugin-harness.test.ts
@@ -1,0 +1,270 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+import { createPluginHarnessSession } from "../../src/fixtures/plugin-harness";
+import type { CreatePluginHarnessOptions } from "../../src/fixtures/plugin-harness";
+import { createExecResult } from "../helpers/create-exec-result";
+import { cleanupTempDirectories, createTempDir } from "../helpers/create-temp-dir";
+import type { CommandTransport } from "../../src/core/types";
+
+const PLUGIN_ID = "harness-plugin";
+const READY_COMMAND = "harness-plugin:ready";
+
+const tempDirectories: string[] = [];
+
+afterEach(async () => {
+  await cleanupTempDirectories(tempDirectories);
+});
+
+interface HarnessFixture {
+  dataPath: string;
+  events: string[];
+  lockRoot: string;
+  setEnabled(value: boolean): void;
+  setThrowOnDisable(value: boolean): void;
+  transport: CommandTransport;
+  vaultRoot: string;
+}
+
+async function createHarnessFixture(): Promise<HarnessFixture> {
+  const vaultRoot = await createTempDir(tempDirectories, "obsidian-e2e-harness-vault-");
+  const lockRoot = await createTempDir(tempDirectories, "obsidian-e2e-harness-locks-");
+  const dataPath = path.join(vaultRoot, ".obsidian", "plugins", PLUGIN_ID, "data.json");
+
+  await fs.mkdir(path.dirname(dataPath), { recursive: true });
+  await fs.writeFile(dataPath, `${JSON.stringify({ seed: true }, null, 2)}\n`, "utf8");
+
+  const events: string[] = [];
+  let enabled = true;
+  let throwOnDisable = false;
+
+  const transport: CommandTransport = async (request) => {
+    if (request.argv[0] === "--help") {
+      events.push("verify");
+      return createExecResult(request.bin, request.argv, "usage\n");
+    }
+
+    const [, command, ...rest] = request.argv;
+    const args = Object.fromEntries(
+      rest
+        .filter((entry) => entry.includes("="))
+        .map((entry) => {
+          const [key, ...value] = entry.split("=");
+          return [key, value.join("=")];
+        }),
+    );
+
+    if (command === "vault" && args.info === "path") {
+      return createExecResult(request.bin, request.argv, `${vaultRoot}\n`);
+    }
+
+    if (command === "commands") {
+      events.push("commands");
+      return createExecResult(request.bin, request.argv, `${READY_COMMAND}\n`);
+    }
+
+    if (command === "plugin") {
+      return createExecResult(request.bin, request.argv, `enabled\t${enabled}\n`);
+    }
+
+    if (command === "plugin:enable") {
+      enabled = true;
+      events.push("plugin:enable");
+      return createExecResult(request.bin, request.argv, "");
+    }
+
+    if (command === "plugin:disable") {
+      if (throwOnDisable) {
+        throw new Error("plugin:disable failed");
+      }
+
+      enabled = false;
+      events.push("plugin:disable");
+      return createExecResult(request.bin, request.argv, "");
+    }
+
+    if (command === "plugin:reload") {
+      events.push("plugin:reload");
+      return createExecResult(request.bin, request.argv, "");
+    }
+
+    if (command === "eval") {
+      const code = args.code ?? "";
+
+      if (code.includes("delete window.__obsidianE2ELock")) {
+        events.push("eval:clearMarker");
+        return createExecResult(request.bin, request.argv, "cleared\n");
+      }
+
+      if (code.includes("__obsidianE2ELock")) {
+        events.push("eval:marker");
+        return createExecResult(request.bin, request.argv, "{}\n");
+      }
+
+      if (code.includes("__obsidianE2EPlugins")) {
+        events.push("eval:loaded");
+        return createExecResult(
+          request.bin,
+          request.argv,
+          `${JSON.stringify({ ok: true, value: true })}\n`,
+        );
+      }
+
+      events.push("eval:evalJson");
+      return createExecResult(
+        request.bin,
+        request.argv,
+        `${JSON.stringify({ ok: true, value: true })}\n`,
+      );
+    }
+
+    throw new Error(`Unhandled transport request: ${request.argv.join(" ")}`);
+  };
+
+  return {
+    dataPath,
+    events,
+    lockRoot,
+    setEnabled(value: boolean) {
+      enabled = value;
+    },
+    setThrowOnDisable(value: boolean) {
+      throwOnDisable = value;
+    },
+    transport,
+    vaultRoot,
+  };
+}
+
+function baseOptions(fixture: HarnessFixture): CreatePluginHarnessOptions {
+  return {
+    captureOnFailure: false,
+    pluginId: PLUGIN_ID,
+    reload: { intervalMs: 10, readyCommandId: READY_COMMAND, timeoutMs: 5_000 },
+    sharedVaultLock: { lockRoot: fixture.lockRoot, onBusy: "fail", timeoutMs: 5_000 },
+    transport: fixture.transport,
+    vault: "dev",
+  };
+}
+
+function drain(events: string[]): string[] {
+  const snapshot = [...events];
+  events.length = 0;
+  return snapshot;
+}
+
+describe("createPluginHarnessSession", () => {
+  it("drives the suite lifecycle in order and restores data before teardown", async () => {
+    const fixture = await createHarnessFixture();
+    let contentAtRestoreHook: string | undefined;
+
+    const session = createPluginHarnessSession(
+      {
+        ...baseOptions(fixture),
+        async beforeDataRestore() {
+          fixture.events.push("beforeDataRestore");
+          contentAtRestoreHook = await fs.readFile(fixture.dataPath, "utf8");
+        },
+        async waitUntilReady() {
+          fixture.events.push("predicate");
+          return true;
+        },
+      },
+      "lifecycle",
+    );
+
+    await session.setup();
+    const setupEvents = drain(fixture.events);
+
+    // Lock marker publishes before the plugin reload, which readies before the predicate.
+    expect(setupEvents.indexOf("eval:marker")).toBeLessThan(setupEvents.indexOf("plugin:reload"));
+    expect(setupEvents.indexOf("plugin:reload")).toBeLessThan(setupEvents.indexOf("eval:loaded"));
+    expect(setupEvents.indexOf("eval:loaded")).toBeLessThan(setupEvents.indexOf("predicate"));
+
+    await session.resetDiagnostics();
+    expect(drain(fixture.events)).toEqual(["eval:evalJson"]);
+
+    const context = session.getContext();
+    expect(context.plugin.id).toBe(PLUGIN_ID);
+    await context.plugin.data().write({ changed: true });
+    drain(fixture.events);
+
+    await session.restoreData();
+    const restoreEvents = drain(fixture.events);
+    const contentAfterRestore = await fs.readFile(fixture.dataPath, "utf8");
+
+    // beforeDataRestore runs while the test's data is still on disk, before the restore.
+    expect(contentAtRestoreHook).toContain('"changed"');
+    expect(contentAfterRestore).toContain('"seed"');
+    expect(contentAfterRestore).not.toContain('"changed"');
+    expect(restoreEvents.indexOf("beforeDataRestore")).toBeLessThan(
+      restoreEvents.indexOf("plugin:disable"),
+    );
+    expect(restoreEvents).toContain("plugin:enable");
+    expect(restoreEvents).toContain("predicate");
+
+    await session.teardown();
+    const teardownEvents = drain(fixture.events);
+
+    expect(teardownEvents).toContain("eval:clearMarker");
+    // The vault lock directory is released.
+    await expect(fs.readdir(fixture.lockRoot)).resolves.toHaveLength(0);
+    expect(() => session.getContext()).toThrow(/not initialized/u);
+  });
+
+  it("aggregates multiple teardown errors and still releases the lock", async () => {
+    const fixture = await createHarnessFixture();
+    fixture.setEnabled(false);
+    fixture.setThrowOnDisable(true);
+
+    const session = createPluginHarnessSession(
+      {
+        ...baseOptions(fixture),
+        beforeDataRestore() {
+          throw new Error("beforeDataRestore failed");
+        },
+        async waitUntilReady() {
+          return true;
+        },
+      },
+      "teardown",
+    );
+
+    await session.setup();
+
+    const error = await session.teardown().then(
+      () => undefined,
+      (thrown: unknown) => thrown,
+    );
+
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors).toHaveLength(2);
+    await expect(fs.readdir(fixture.lockRoot)).resolves.toHaveLength(0);
+  });
+
+  it("runs the symlink preflight after the lock and releases it on failure", async () => {
+    const fixture = await createHarnessFixture();
+
+    const session = createPluginHarnessSession(
+      {
+        ...baseOptions(fixture),
+        symlinkArtifacts: ["main.js"],
+        symlinkRepoRoot: fixture.vaultRoot,
+      },
+      "preflight",
+    );
+
+    const error = await session.setup().then(
+      () => undefined,
+      (thrown: unknown) => thrown,
+    );
+
+    expect((error as Error).message).toContain("preflight failed");
+    // The lock was acquired (marker published) before the preflight ran, and released on failure.
+    expect(fixture.events).toContain("eval:marker");
+    expect(fixture.events).not.toContain("plugin:reload");
+    await expect(fs.readdir(fixture.lockRoot)).resolves.toHaveLength(0);
+  });
+});

--- a/tests/helpers/stub-obsidian-client.ts
+++ b/tests/helpers/stub-obsidian-client.ts
@@ -28,6 +28,7 @@ interface CreateStubObsidianClientOptions {
   notices?: DevNoticeEvent[];
   onEval?: (code: string) => Awaitable<unknown>;
   onEvalJson?: (code: string) => Awaitable<unknown>;
+  onEvalJsonAsync?: (code: string) => Awaitable<unknown>;
   onEvalRaw?: (code: string) => Awaitable<string>;
   onScreenshot?: (path: string) => Promise<string> | string;
   pluginFactory?: (client: ObsidianClient, id: string) => PluginHandle;
@@ -122,6 +123,21 @@ export function createStubObsidianClient(options: CreateStubObsidianClientOption
         }
 
         throw new Error(`Unhandled dev.evalJson code: ${code}`);
+      },
+      async evalJsonAsync(code: string) {
+        if (options.onEvalJsonAsync) {
+          return options.onEvalJsonAsync(code) as never;
+        }
+
+        if (options.onEvalJson) {
+          return options.onEvalJson(code) as never;
+        }
+
+        if (options.onEval) {
+          return options.onEval(code) as never;
+        }
+
+        throw new Error(`Unhandled dev.evalJsonAsync code: ${code}`);
       },
       async evalRaw(code: string) {
         if (options.onEvalRaw) {


### PR DESCRIPTION
## What

Three additive helpers (plus one small option) that let the three plugin repos
delete their hand-rolled e2e harnesses:

- **`obsidian.dev.evalJsonAsync(code)`** - the byte-identical async-eval that
  podnotes and metaedit both ship today, ported into core. It runs an async IIFE
  that awaits the evaluated body, then serializes the same
  `{ ok, value } | { ok: false, error }` envelope `evalJson` already uses, decoded
  through the existing `parseEvalJsonEnvelope` path and rethrown as a
  `DevEvalError` carrying the remote message and stack. The synchronous and async
  builders now share one serializer/failure branch, so `buildEvalJsonCode` output
  stays byte-for-byte identical.
- **`resolveObsidianEnvOptions()` / `verifyVaultPath()`** - map the canonical
  `OBSIDIAN_E2E_VAULT` / `_VAULT_PATH` / `_OBSIDIAN_HOME` env (with an optional
  legacy per-plugin prefix fallback) into spreadable client options. `HOME` is
  injected into `defaultExecOptions.env` per-client, never mutating `process.env`
  (quickadd's pattern, promoted to the package default). `verifyVaultPath` refuses
  to run against the wrong vault.
- **`createPluginHarness()`** (from `obsidian-e2e/vitest`) - a suite-scoped
  fixture built on the existing per-test internals (lock + marker, sandbox,
  artifact capture, snapshot/restore) rather than duplicating them. `beforeAll`
  locks, runs an optional symlink preflight, sandboxes, and reloads to the ready
  command plus a `waitUntilReady` predicate; `afterEach` resets diagnostics, runs
  `beforeDataRestore`, restores `data.json`, and re-readies; `afterAll` runs an
  ordered, error-aggregating teardown that always releases the lock. It returns
  the `(testName) => () => { obsidian, plugin, sandbox }` getter the hand-rolled
  harnesses already expose.
- **`PluginWaitUntilReadyOptions.predicate`** - fell out naturally; lets
  `plugin.reload({ readyOptions: { predicate } })` assert readiness beyond the
  ready command.

## Why

Per the harness reconciliation, quickadd, podnotes, and metaedit hand-roll ~600
lines of near-identical `beforeAll`/`afterEach`/`afterAll`, `evalJsonAsync`, and
env-plumbing that the package's fixture stack already covers internally - the
three top gaps were `evalJsonAsync` (3/3 repos), an env->client-options resolver
(3/3, all subtly different), and suite-scoped orchestration (3/3). These
additions let each consumer shrink to ~25 lines.

## Compatibility

Additive only - no existing export changes, ships as a **0.7.x minor**. The new
`beforeSandbox` seam on `createInternalTestContext` is private (not exported).

## Verification

- `vp check` clean
- `vp test` green: 234 passed + 1 skipped (218 baseline + 17 new: async-eval
  envelope, env canonical/legacy mapping + HOME injection + expected-path throw,
  and a harness lifecycle/ordering + teardown-aggregation + preflight smoke)
- `vp pack` clean; new exports present in the built `.d.mts`

## Consumer migration

Separate PR per consumer for bisectability, in order: **metaedit -> podnotes ->
quickadd**. metaedit is the simplest (swap client creation for
`resolveObsidianEnvOptions`, replace the harness body with `createPluginHarness`,
re-export `evalJsonAsync`); podnotes additionally exercises `beforeDataRestore`
(detach views + flush saves must run before `restoreData`) and the extra ready
predicate; quickadd is the biggest shape change (decide per file whether to adopt
the harness or just the env resolver + `evalJsonAsync`, and verify the
long-async apply-template case before deleting its window-global poll).
