### PR TITLE
fix(e2e): bind createPluginHarness hooks to vitest (0.8.0 breaks real-vitest consumers)

### DIFF
--- a/.changeset/plugin-harness-vitest-binding.md
+++ b/.changeset/plugin-harness-vitest-binding.md
@@ -1,0 +1,5 @@
+---
+"obsidian-e2e": patch
+---
+
+Fix `createPluginHarness` so its `beforeAll`/`beforeEach`/`afterEach`/`afterAll` hooks bind to `vitest` instead of `vite-plus/test`. The harness registers these hooks inside the consumer's test files, which run under the consumer's own vitest; binding them to a different runner instance left every e2e file failing at collection with "Vitest failed to find the current suite". `vitest` is now declared as an optional peer dependency.

--- a/package.json
+++ b/package.json
@@ -67,7 +67,13 @@
     "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
   },
   "peerDependencies": {
-    "vite-plus": "^0.1.11"
+    "vite-plus": "^0.1.11",
+    "vitest": ">=3"
+  },
+  "peerDependenciesMeta": {
+    "vitest": {
+      "optional": true
+    }
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
 
   .:
     dependencies:
+      vitest:
+        specifier: npm:@voidzero-dev/vite-plus-test@latest
+        version: '@voidzero-dev/vite-plus-test@0.1.11(@types/node@25.5.0)(jiti@2.6.1)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))(yaml@2.8.2)'
       yaml:
         specifier: ^2.8.2
         version: 2.8.2
@@ -34,9 +37,6 @@ importers:
       vite-plus:
         specifier: latest
         version: 0.1.11(@types/node@25.5.0)(jiti@2.6.1)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))(yaml@2.8.2)
-      vitest:
-        specifier: npm:@voidzero-dev/vite-plus-test@latest
-        version: '@voidzero-dev/vite-plus-test@0.1.11(@types/node@25.5.0)(jiti@2.6.1)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.2))(yaml@2.8.2)'
 
 packages:
 

--- a/src/fixtures/plugin-harness.ts
+++ b/src/fixtures/plugin-harness.ts
@@ -1,8 +1,14 @@
 import { readlink } from "node:fs/promises";
 import path from "node:path";
 
-import { afterAll, afterEach, beforeAll, beforeEach } from "vite-plus/test";
-import type { TestContext as VitestTestContext } from "vite-plus/test";
+// Bind to "vitest" (not "vite-plus/test"): createPluginHarness registers these
+// lifecycle hooks in the *consumer's* test files, which run under the consumer's
+// own vitest. Registering on a different runner instance leaves the hooks unable
+// to find the current suite. Inside this package "vitest" is aliased to
+// @voidzero-dev/vite-plus-test (the same runner vite-plus/test re-exports), so
+// the package's own suite stays consistent while dist externalizes "vitest".
+import { afterAll, afterEach, beforeAll, beforeEach } from "vitest";
+import type { TestContext as VitestTestContext } from "vitest";
 
 import type { FailureArtifactTask } from "../artifacts/failure-artifacts";
 import type {

--- a/tests/fixtures/plugin-harness.test.ts
+++ b/tests/fixtures/plugin-harness.test.ts
@@ -155,6 +155,25 @@ function drain(events: string[]): string[] {
   return snapshot;
 }
 
+describe("createPluginHarness runner binding", () => {
+  it('imports its lifecycle hooks from "vitest", the consumer\'s runner', async () => {
+    // createPluginHarness registers beforeAll/beforeEach/afterEach/afterAll inside
+    // the *consumer's* test files, which run under the consumer's own vitest. If
+    // those hooks are imported from a different runner instance (e.g.
+    // "vite-plus/test"), they register on a runner that never sees the consumer's
+    // suite, so every file fails at collection with "failed to find the current
+    // suite". Guarding the import specifier keeps the binding correct; the package's
+    // own suite aliases "vitest" to the same vite-plus-test runner, so it stays green.
+    const source = await fs.readFile(
+      path.join(__dirname, "..", "..", "src", "fixtures", "plugin-harness.ts"),
+      "utf8",
+    );
+
+    expect(source).toMatch(/import\s*\{[^}]*\bbeforeAll\b[^}]*\}\s*from\s*"vitest"/u);
+    expect(source).not.toMatch(/\bbeforeAll\b[^\n]*from\s*"vite-plus\/test"/u);
+  });
+});
+
 describe("createPluginHarnessSession", () => {
   it("drives the suite lifecycle in order and restores data before teardown", async () => {
     const fixture = await createHarnessFixture();


### PR DESCRIPTION
## What

`createPluginHarness` imported its `beforeAll`/`beforeEach`/`afterEach`/`afterAll` hooks from `vite-plus/test`. Those hooks are registered inside the *consumer's* test files, which run under the consumer's own `vitest`. Registering on a different runner instance means the hooks never see the suite the consumer's `describe`/`test` built, so every consumer e2e file fails at collection with:

```
Error: Vitest failed to find the current suite.
```

This bind now points at `vitest`. Inside this package `vitest` is aliased to `@voidzero-dev/vite-plus-test` (the same 0.1.11 runner `vite-plus/test` re-exports), so the package's own `vp test` suite stays green; in the built `dist/vitest.mjs` the import externalizes as `from "vitest"`, so consumers bind to their own real vitest. `vitest` is declared as an optional peer dependency.

## Why it matters now

The published **0.8.0 ships the broken binding**. Any consumer installing `obsidian-e2e@^0.8.0` and running e2e under the standard `vitest` runner (the three target repos - metaedit, podnotes, quickadd - all do) hits the collection failure on every file. This needs a **0.8.1** patch (changeset included).

## How it was found

The metaedit canary migration onto `createPluginHarness`: all 16 e2e files died identically at `plugin-harness.ts` `beforeAll`. With this fix the suite runs (86/103 passing; the remaining failures are pre-existing modal/suggester UI flakiness, verified identical under metaedit's old hand-rolled harness).

## Test

Added a regression test (`tests/fixtures/plugin-harness.test.ts`) asserting the lifecycle hooks are imported from `"vitest"`, not `"vite-plus/test"`, with the rationale inline. Full suite: 240 passed, 1 skipped. `vp check` clean.