### PR TITLE
fix(eval): kickoff-and-poll evalJsonAsync so lost CLI replies are recoverable

### DIFF
--- a/.changeset/polled-eval-json-async.md
+++ b/.changeset/polled-eval-json-async.md
@@ -1,0 +1,27 @@
+---
+"obsidian-e2e": minor
+---
+
+`evalJsonAsync` no longer holds a single CLI command open for the lifetime of
+the awaited promise (#21). The `obsidian eval` command's reply is the only
+carrier of the result, so a client timeout kill or a renderer reload mid-eval
+lost the value forever even when the operation itself completed (reproduced
+against the real CLI socket: a vault reload mid-eval orphans the pending
+`executeJavaScript` promise and the CLI hangs indefinitely).
+
+`evalJsonAsync` now runs a kickoff-and-poll protocol: a short kickoff command,
+sent exactly once, starts the operation and records its eventual
+`{ ok, value }` envelope under a per-operation nonce inside the app, and short
+idempotent poll reads retrieve it. A lost reply is recovered by reading again;
+the kickoff is never resent, so the evaluated code cannot run twice.
+`timeoutMs` is now the overall deadline for the awaited result, with each
+internal CLI command on its own short budget. Consumer-suite fire-and-poll
+workarounds (window global + short `evalJson` reads) are obsolete.
+
+Irrecoverable states throw the new `DevEvalAsyncError` whose `reason` names
+the precise transport state - `ambiguous-delivery`, `context-reset`, or
+`still-pending` - instead of a generic 30s timeout. The transport now throws a
+typed `ObsidianCommandTimeoutError` on command timeouts, and the error classes
+(`DevEvalError`, `DevEvalAsyncError`, `ObsidianCommandError`,
+`ObsidianCommandTimeoutError`, `WaitForTimeoutError`) are exported from the
+package root.

--- a/README.md
+++ b/README.md
@@ -903,9 +903,7 @@ test("inspects live UI state", async ({ obsidian }) => {
 `obsidian.dev.eval()` remains the low-level escape hatch and preserves the raw
 CLI parsing behavior. Use `obsidian.dev.evalJson()` when you want JSON-safe
 typed results and remote error details, `obsidian.dev.evalJsonAsync()` when the
-evaluated code is an async body whose resolved value you need (it awaits the
-promise inside Obsidian before serializing the same `{ ok, value }` envelope,
-rethrowing failures as a `DevEvalError` with the remote message and stack), and
+evaluated code is an async body whose resolved value you need, and
 `obsidian.dev.evalRaw()` when you intentionally need the unstructured CLI output.
 The `evalJson`/`evalJsonAsync` envelope is wrapped in per-call sentinel markers,
 so plugin console output emitted on the eval channel while the code runs (e.g.
@@ -914,6 +912,39 @@ polling workaround is needed for logging-heavy operations. `dev.dom()` and
 `dev.screenshot()` remain the safer wrappers around the built-in developer CLI
 commands. Screenshot behavior depends on the active desktop environment, so
 start by validating it locally before relying on it in automation.
+
+### How `evalJsonAsync` awaits long operations
+
+A single `obsidian eval` CLI command holds one socket request open for the whole
+lifetime of an awaited promise, and its reply is the only carrier of the result:
+a timeout kill or a renderer reload mid-eval loses the value forever even when
+the operation itself completed (#21). `evalJsonAsync` therefore never holds a
+long command open. It sends a short kickoff command exactly once - the command
+starts the operation and records its eventual `{ ok, value }` envelope under a
+per-operation nonce inside the app - then retrieves the envelope with short
+idempotent poll reads. A lost reply is recovered by simply reading again, and
+because the kickoff is never resent, the evaluated code cannot run twice.
+
+`timeoutMs` (per call or via `defaultExecOptions`) is the overall deadline for
+the awaited result; each internal CLI command runs on its own short budget.
+Successful results resolve the value and rethrow in-app failures as
+`DevEvalError`, exactly as before. When the result cannot be produced, the call
+throws `DevEvalAsyncError` whose `reason` names the precise transport state
+instead of a generic timeout:
+
+- `ambiguous-delivery`: the kickoff command failed or its reply was lost, and
+  no in-app record of the operation appeared before the deadline; it may or may
+  not have started. The kickoff is never resent, preserving exactly-once
+  execution; the underlying CLI failure is attached as `causeError`.
+- `context-reset`: the operation was confirmed running and then the eval
+  context was wiped (e.g. an app or vault reload); the result was discarded
+  with the previous context.
+- `still-pending`: the awaited promise has not settled within the deadline; the
+  operation may still complete in-app afterwards.
+
+Hand-rolled fire-and-poll loops (a `window` global plus repeated short
+`evalJson` reads) are obsolete: `evalJsonAsync` is that pattern, managed by the
+package.
 
 ## Layer Boundaries
 

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -125,7 +125,9 @@ export function createObsidianClient(options: CreateObsidianClientOptions): Obsi
       return runEvalJson<T>(this, code, execOptions);
     },
     async evalJsonAsync<T = unknown>(code: string, execOptions: ExecOptions = {}) {
-      return runEvalJsonAsync<T>(this, code, execOptions);
+      // The merged timeoutMs is the overall deadline for the kickoff-and-poll
+      // protocol; each internal CLI command stays on its own short budget.
+      return runEvalJsonAsync<T>(this, code, mergeExecOptions(defaultExecOptions, execOptions));
     },
     async evalRaw(code: string, execOptions: ExecOptions = {}) {
       return client.execText(

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -31,6 +31,60 @@ export class ObsidianCommandError extends Error {
     this.result = result;
   }
 }
+/**
+ * The spawned CLI process exceeded its time budget and was killed. The command
+ * may still have been delivered to (and executed by) the running app - only the
+ * reply is known to be lost.
+ */
+export class ObsidianCommandTimeoutError extends Error {
+  readonly argv: string[];
+  readonly bin: string;
+  readonly timeoutMs: number;
+
+  constructor(bin: string, argv: string[], timeoutMs: number) {
+    super(`Command timed out after ${timeoutMs}ms: ${bin} ${argv.join(" ")}`);
+    this.name = "ObsidianCommandTimeoutError";
+    this.argv = argv;
+    this.bin = bin;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+/**
+ * Failure taxonomy for the kickoff-and-poll `evalJsonAsync` protocol. Each
+ * reason names a distinct, observed transport state instead of a generic
+ * timeout:
+ *
+ * - `ambiguous-delivery`: the kickoff command failed or its reply was lost,
+ *   and no in-app record of the operation appeared before the deadline. It may
+ *   or may not have started; the kickoff is never resent (there is no
+ *   structural delivery acknowledgement), so the code cannot run twice.
+ * - `context-reset`: the eval context was confirmed running and then vanished
+ *   (e.g. an app/vault reload wiped the renderer); the result was discarded
+ *   with the previous context.
+ * - `still-pending`: the operation is confirmed running but its promise has not
+ *   settled within the deadline. It may still complete in-app afterwards.
+ */
+export type DevEvalAsyncFailureReason = "ambiguous-delivery" | "context-reset" | "still-pending";
+
+export class DevEvalAsyncError extends Error {
+  readonly causeError?: unknown;
+  readonly nonce: string;
+  readonly reason: DevEvalAsyncFailureReason;
+
+  constructor(
+    message: string,
+    reason: DevEvalAsyncFailureReason,
+    nonce: string,
+    causeError?: unknown,
+  ) {
+    super(message);
+    this.name = "DevEvalAsyncError";
+    this.reason = reason;
+    this.nonce = nonce;
+    this.causeError = causeError;
+  }
+}
 
 export class WaitForTimeoutError extends Error {
   readonly causeError?: unknown;

--- a/src/core/transport.ts
+++ b/src/core/transport.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 
-import { ObsidianCommandError } from "./errors";
+import { ObsidianCommandError, ObsidianCommandTimeoutError } from "./errors";
 import type { CommandTransport, ExecuteRequest, ExecResult } from "./types";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -30,10 +30,12 @@ export const executeCommand: CommandTransport = async ({
     stderrChunks.push(Buffer.from(chunk));
   });
 
+  // Executor form on purpose: `Promise.withResolvers` is ES2024/Node >= 22,
+  // and the package's engines floor is Node ^20.19.0.
   const exitCode = await new Promise<number>((resolve, reject) => {
     const timer = setTimeout(() => {
       child.kill("SIGTERM");
-      reject(new Error(`Command timed out after ${timeoutMs}ms: ${bin} ${argv.join(" ")}`));
+      reject(new ObsidianCommandTimeoutError(bin, argv, timeoutMs));
     }, timeoutMs);
 
     child.on("error", (error) => {

--- a/src/dev/eval-json.ts
+++ b/src/dev/eval-json.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "node:crypto";
 
-import { DevEvalError } from "../core/errors";
+import { DevEvalAsyncError, DevEvalError, type DevEvalAsyncFailureReason } from "../core/errors";
 import type { DevEvalErrorPayload, ExecOptions, ObsidianDevHandle } from "../core/types";
+import { sleep } from "../core/wait";
 
 interface EvalJsonSuccess {
   ok: true;
@@ -41,9 +42,10 @@ export function createEvalJsonFrame(): EvalJsonFrame {
   };
 }
 
-// The serializer and the failure branch are shared verbatim by the synchronous
-// and asynchronous builders so both produce the same {ok,value}|{ok:false,error}
-// envelope, decoded by the single parseEvalJsonEnvelope path below.
+// The serializer and the error payload are shared verbatim by the synchronous
+// builder and the async kickoff builder so both produce the same
+// {ok,value}|{ok:false,error} envelope, decoded by the single
+// unwrapEvalJsonEnvelope path below.
 const EVAL_JSON_SERIALIZER = [
   "const __obsidianE2ESerialize=(value,path='$')=>{",
   "if(value===null){return null;}",
@@ -61,8 +63,10 @@ const EVAL_JSON_SERIALIZER = [
   "};",
 ].join("");
 
-const EVAL_JSON_FAILURE_BRANCH =
-  "return __obsidianE2EFrame(JSON.stringify({ok:false,error:{message:error instanceof Error?error.message:String(error),name:error instanceof Error?error.name:'Error',stack:error instanceof Error?error.stack:undefined}}));";
+const EVAL_JSON_ERROR_PAYLOAD =
+  "{message:error instanceof Error?error.message:String(error),name:error instanceof Error?error.name:'Error',stack:error instanceof Error?error.stack:undefined}";
+
+const EVAL_JSON_FAILURE_BRANCH = `return __obsidianE2EFrame(JSON.stringify({ok:false,error:${EVAL_JSON_ERROR_PAYLOAD}}));`;
 
 function buildFrameHelper(frame: EvalJsonFrame): string {
   return `const __obsidianE2EFrame=(payload)=>${JSON.stringify(frame.begin)}+payload+${JSON.stringify(frame.end)};`;
@@ -77,19 +81,6 @@ export async function runEvalJson<T>(
 
   return parseEvalJsonEnvelope<T>(
     await dev.evalRaw(buildEvalJsonCode(code, frame), execOptions),
-    frame,
-  );
-}
-
-export async function runEvalJsonAsync<T>(
-  dev: Pick<ObsidianDevHandle, "evalRaw">,
-  code: string,
-  execOptions: ExecOptions = {},
-): Promise<T> {
-  const frame = createEvalJsonFrame();
-
-  return parseEvalJsonEnvelope<T>(
-    await dev.evalRaw(buildEvalJsonAsyncCode(code, frame), execOptions),
     frame,
   );
 }
@@ -109,24 +100,181 @@ export function buildEvalJsonCode(code: string, frame: EvalJsonFrame): string {
   ].join("");
 }
 
-export function buildEvalJsonAsyncCode(code: string, frame: EvalJsonFrame): string {
+/**
+ * In-app registry for the kickoff-and-poll `evalJsonAsync` protocol. The
+ * `obsidian eval` CLI command holds a single socket request open for the whole
+ * lifetime of an awaited promise, and its reply is the only carrier of the
+ * result - a client-side timeout kill or a renderer reload mid-eval loses the
+ * value forever even when the operation itself completed (#21). The protocol
+ * below keeps every CLI command short instead: a kickoff command starts the
+ * operation and records its eventual envelope under a per-operation nonce, and
+ * idempotent poll reads retrieve it, so a lost reply is recoverable by reading
+ * again.
+ */
+const ASYNC_EVAL_REGISTRY = "__obsidianE2EAsyncEvals";
+
+const ASYNC_EVAL_POLL_INTERVAL_MS = 100;
+/** Budget for each internal CLI command; polls make long waits out of short reads. */
+const ASYNC_EVAL_COMMAND_TIMEOUT_MS = 10_000;
+/** Best-effort cleanup only; never worth stalling a passed test for. */
+const ASYNC_EVAL_CLEANUP_TIMEOUT_MS = 2_000;
+/** Mirrors the transport's default command timeout, which bounded the old single-command form. */
+const DEFAULT_ASYNC_EVAL_TIMEOUT_MS = 30_000;
+
+interface AsyncEvalDoneEntry {
+  envelope: EvalJsonEnvelope;
+  state: "done";
+}
+
+interface AsyncEvalPendingEntry {
+  state: "pending";
+}
+
+type AsyncEvalEntry = AsyncEvalDoneEntry | AsyncEvalPendingEntry;
+
+/**
+ * Kickoff command: registers `{state:'pending'}` under the nonce synchronously,
+ * starts the awaited operation, and returns immediately. The completion handler
+ * stores the same `{ok,value}|{ok:false,error}` envelope the synchronous
+ * builder produces (serialization happens at completion time, so a
+ * non-serializable resolution becomes a stored error envelope).
+ */
+export function buildEvalJsonAsyncKickoffCode(
+  code: string,
+  frame: EvalJsonFrame,
+  nonce: string,
+): string {
   // Indirect `eval` parses its argument as a script, where a top-level `await`
   // is a SyntaxError. Wrapping the caller's code as the expression body of an
   // async arrow makes `await` valid while still yielding the expression's value,
   // so both `await load()` and a plain promise-returning expression work.
   const asyncExpression = `(async()=>(${code}))()`;
   return [
-    "(async()=>{",
+    "(()=>{",
     `const __obsidianE2ECode=${JSON.stringify(asyncExpression)};`,
     buildFrameHelper(frame),
     EVAL_JSON_SERIALIZER,
-    "try{",
-    "return __obsidianE2EFrame(JSON.stringify({ok:true,value:__obsidianE2ESerialize(await (0,eval)(__obsidianE2ECode))}));",
-    "}catch(error){",
-    EVAL_JSON_FAILURE_BRANCH,
-    "}",
+    `const __obsidianE2ERegistry=globalThis.${ASYNC_EVAL_REGISTRY}??(globalThis.${ASYNC_EVAL_REGISTRY}=Object.create(null));`,
+    `const __obsidianE2ENonce=${JSON.stringify(nonce)};`,
+    "__obsidianE2ERegistry[__obsidianE2ENonce]={state:'pending'};",
+    "(async()=>{",
+    "try{return {ok:true,value:__obsidianE2ESerialize(await (0,eval)(__obsidianE2ECode))};}",
+    `catch(error){return {ok:false,error:${EVAL_JSON_ERROR_PAYLOAD}};}`,
+    "})().then((envelope)=>{__obsidianE2ERegistry[__obsidianE2ENonce]={state:'done',envelope};});",
+    "return __obsidianE2EFrame(JSON.stringify({ok:true,value:'started'}));",
     "})()",
   ].join("");
+}
+
+/** Pure read; safe to repeat after any lost or failed reply. */
+export function buildEvalJsonAsyncPollCode(nonce: string): string {
+  return `globalThis.${ASYNC_EVAL_REGISTRY}?.[${JSON.stringify(nonce)}]??null`;
+}
+
+export function buildEvalJsonAsyncCleanupCode(nonce: string): string {
+  return `(()=>{const registry=globalThis.${ASYNC_EVAL_REGISTRY};if(registry){delete registry[${JSON.stringify(nonce)}];}return true;})()`;
+}
+
+export async function runEvalJsonAsync<T>(
+  dev: Pick<ObsidianDevHandle, "evalRaw">,
+  code: string,
+  execOptions: ExecOptions = {},
+): Promise<T> {
+  const timeoutMs = execOptions.timeoutMs ?? DEFAULT_ASYNC_EVAL_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+  const nonce = randomUUID();
+
+  // Spread the resolved options so cwd/env flow into every internal command;
+  // allowNonZeroExit is forced off so CLI failures classify as failures, and
+  // timeoutMs becomes the per-command budget clamped to the overall deadline.
+  const commandOptions = (budgetMs: number): ExecOptions => ({
+    ...execOptions,
+    allowNonZeroExit: false,
+    timeoutMs: Math.max(1, Math.min(budgetMs, deadline - Date.now())),
+  });
+  const pause = async () => {
+    await sleep(Math.max(0, Math.min(ASYNC_EVAL_POLL_INTERVAL_MS, deadline - Date.now())));
+  };
+  const fail = (reason: DevEvalAsyncFailureReason, message: string, causeError?: unknown) =>
+    new DevEvalAsyncError(`${message} (nonce ${nonce})`, reason, nonce, causeError);
+
+  // Kickoff phase: sent exactly once, ever. There is no structural delivery
+  // acknowledgement other than the framed reply itself, so any failure here
+  // leaves delivery unknown and the idempotent poll phase below doubles as the
+  // probe. Never resending is what makes exactly-once execution literal.
+  let confirmed = false;
+  let lastError: unknown;
+
+  const kickoffFrame = createEvalJsonFrame();
+  try {
+    parseEvalJsonEnvelope<string>(
+      await dev.evalRaw(
+        buildEvalJsonAsyncKickoffCode(code, kickoffFrame, nonce),
+        commandOptions(ASYNC_EVAL_COMMAND_TIMEOUT_MS),
+      ),
+      kickoffFrame,
+    );
+    confirmed = true;
+  } catch (error) {
+    lastError = error;
+  }
+
+  // Poll phase: idempotent reads until the envelope appears or the deadline
+  // names the precise terminal state.
+  while (Date.now() < deadline) {
+    let entry: AsyncEvalEntry | null;
+    try {
+      entry = await runEvalJson<AsyncEvalEntry | null>(
+        dev,
+        buildEvalJsonAsyncPollCode(nonce),
+        commandOptions(ASYNC_EVAL_COMMAND_TIMEOUT_MS),
+      );
+    } catch (error) {
+      lastError = error;
+      await pause();
+      continue;
+    }
+
+    if (entry === null) {
+      if (confirmed) {
+        throw fail(
+          "context-reset",
+          "The Obsidian eval context was reset (e.g. an app or vault reload) while the evalJsonAsync operation was running; its result was discarded with the previous context",
+        );
+      }
+      // Kickoff reply was lost and the operation has not (yet) appeared: the
+      // kickoff may still be in transit, so keep probing until the deadline.
+    } else {
+      confirmed = true;
+      if (entry.state === "done") {
+        try {
+          await runEvalJson<boolean>(
+            dev,
+            buildEvalJsonAsyncCleanupCode(nonce),
+            commandOptions(ASYNC_EVAL_CLEANUP_TIMEOUT_MS),
+          );
+        } catch {
+          // Best-effort: a leaked entry is one small object in the renderer.
+        }
+        return unwrapEvalJsonEnvelope<T>(entry.envelope);
+      }
+    }
+
+    await pause();
+  }
+
+  if (confirmed) {
+    throw fail(
+      "still-pending",
+      `The evalJsonAsync operation is still pending in Obsidian after ${timeoutMs}ms; the awaited promise has not settled. It may still complete in-app`,
+    );
+  }
+
+  throw fail(
+    "ambiguous-delivery",
+    `The evalJsonAsync kickoff command failed or its reply was lost, and no in-app record of the operation appeared within ${timeoutMs}ms; it may or may not have started. The kickoff was not resent, so the code cannot have run twice`,
+    lastError,
+  );
 }
 
 export function parseDevEvalOutput<T>(raw: string): T {
@@ -143,6 +291,10 @@ export function parseEvalJsonEnvelope<T>(raw: string, frame?: EvalJsonFrame): T 
   const payload = frame ? extractFramedPayload(raw, frame) : normalizeEvalOutput(raw);
   const envelope = JSON.parse(payload) as EvalJsonEnvelope;
 
+  return unwrapEvalJsonEnvelope<T>(envelope);
+}
+
+function unwrapEvalJsonEnvelope<T>(envelope: EvalJsonEnvelope): T {
   if (!envelope.ok) {
     throw new DevEvalError(`Failed to evaluate Obsidian code: ${envelope.error.message}`, {
       ...envelope.error,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,13 @@
 export { createObsidianClient } from "./core/client";
 export {
+  DevEvalAsyncError,
+  DevEvalError,
+  ObsidianCommandError,
+  ObsidianCommandTimeoutError,
+  WaitForTimeoutError,
+} from "./core/errors";
+export type { DevEvalAsyncFailureReason } from "./core/errors";
+export {
   captureFailureArtifacts,
   DEFAULT_FAILURE_ARTIFACTS_DIR,
 } from "./artifacts/failure-artifacts";

--- a/tests/core/transport.test.ts
+++ b/tests/core/transport.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { ObsidianCommandError, ObsidianCommandTimeoutError } from "../../src/core/errors";
+import { executeCommand } from "../../src/core/transport";
+
+describe("executeCommand", () => {
+  it("captures stdout from a completed command", async () => {
+    const result = await executeCommand({
+      argv: ["-e", "process.stdout.write('done')"],
+      bin: process.execPath,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("done");
+  });
+
+  it("throws ObsidianCommandError on nonzero exit with the captured result", async () => {
+    const error = await executeCommand({
+      argv: ["-e", "process.stderr.write('broken'); process.exit(3)"],
+      bin: process.execPath,
+    }).catch((thrown: unknown) => thrown);
+
+    expect(error).toBeInstanceOf(ObsidianCommandError);
+    expect((error as ObsidianCommandError).result.exitCode).toBe(3);
+    expect((error as ObsidianCommandError).result.stderr).toBe("broken");
+  });
+
+  // Real child process and wall clock on purpose: this exercises the actual
+  // spawn/kill timeout path; fake timers cannot advance a separate process.
+  it("kills an overrunning command and rejects with ObsidianCommandTimeoutError", async () => {
+    const error = await executeCommand({
+      argv: ["-e", "setTimeout(() => {}, 60000)"],
+      bin: process.execPath,
+      timeoutMs: 150,
+    }).catch((thrown: unknown) => thrown);
+
+    expect(error).toBeInstanceOf(ObsidianCommandTimeoutError);
+    expect((error as ObsidianCommandTimeoutError).bin).toBe(process.execPath);
+    expect((error as ObsidianCommandTimeoutError).argv).toEqual([
+      "-e",
+      "setTimeout(() => {}, 60000)",
+    ]);
+    expect((error as ObsidianCommandTimeoutError).timeoutMs).toBe(150);
+    expect((error as ObsidianCommandTimeoutError).message).toContain(
+      "Command timed out after 150ms",
+    );
+  });
+});

--- a/tests/dev/eval-json-async.test.ts
+++ b/tests/dev/eval-json-async.test.ts
@@ -1,181 +1,272 @@
-import { describe, expect, it } from "vite-plus/test";
+import { afterEach, describe, expect, it } from "vite-plus/test";
 
 import { createObsidianClient } from "../../src/core/client";
-import { DevEvalError } from "../../src/core/errors";
 import {
-  buildEvalJsonAsyncCode,
+  DevEvalAsyncError,
+  DevEvalError,
+  ObsidianCommandError,
+  ObsidianCommandTimeoutError,
+} from "../../src/core/errors";
+import {
+  buildEvalJsonAsyncCleanupCode,
+  buildEvalJsonAsyncKickoffCode,
+  buildEvalJsonAsyncPollCode,
   createEvalJsonFrame,
   parseEvalJsonEnvelope,
   runEvalJsonAsync,
 } from "../../src/dev/eval-json";
 import { createExecResult, frameEvalPayload } from "../helpers/create-exec-result";
-import type { CommandTransport, ObsidianDevHandle } from "../../src/core/types";
+import type { CommandTransport, ExecOptions, ObsidianDevHandle } from "../../src/core/types";
 
-function stubDev(
-  evalRaw: (code: string) => Promise<string> | string,
-): Pick<ObsidianDevHandle, "evalRaw"> {
-  return {
-    async evalRaw(code) {
-      return evalRaw(code);
-    },
-  };
+const REGISTRY = "__obsidianE2EAsyncEvals";
+
+afterEach(() => {
+  delete (globalThis as Record<string, unknown>)[REGISTRY];
+});
+
+function registryEntries(): Record<string, { state: string }> {
+  return ((globalThis as Record<string, unknown>)[REGISTRY] ?? {}) as Record<
+    string,
+    { state: string }
+  >;
 }
 
-describe("buildEvalJsonAsyncCode", () => {
-  it("emits an async IIFE that awaits the evaluated code", () => {
-    const code = buildEvalJsonAsyncCode("app.foo()", createEvalJsonFrame());
+type CommandBehavior = "drop-reply" | "fail-undelivered" | undefined;
 
-    expect(code.startsWith("(async()=>{")).toBe(true);
+interface EmulatedCommand {
+  behavior: CommandBehavior;
+  code: string;
+  execOptions: ExecOptions;
+  index: number;
+}
+
+/**
+ * Emulates the in-app side of the protocol by actually executing the generated
+ * eval code in this process, so kickoff/poll/cleanup operate on a real
+ * `globalThis` registry. `drop-reply` executes the command and then throws
+ * (delivered, reply lost); `fail-undelivered` throws the CLI connect failure
+ * without executing.
+ */
+function createInAppEmulator(
+  onCommand: (command: Omit<EmulatedCommand, "behavior">) => CommandBehavior = () => undefined,
+) {
+  const commands: EmulatedCommand[] = [];
+  const dev: Pick<ObsidianDevHandle, "evalRaw"> = {
+    async evalRaw(code, execOptions: ExecOptions = {}) {
+      const command = { code, execOptions, index: commands.length };
+      const behavior = onCommand(command);
+      commands.push({ ...command, behavior });
+
+      if (behavior === "fail-undelivered") {
+        throw new ObsidianCommandError("Obsidian command failed with exit code 1: obsidian eval", {
+          argv: ["eval"],
+          command: "obsidian",
+          exitCode: 1,
+          stderr:
+            "The CLI is unable to find Obsidian. Please make sure Obsidian is running and try again.\n",
+          stdout: "",
+        });
+      }
+
+      const output = (await (0, eval)(code)) as string;
+
+      if (behavior === "drop-reply") {
+        throw new ObsidianCommandTimeoutError("obsidian", ["eval"], 10);
+      }
+
+      return output;
+    },
+  };
+
+  return { commands, dev };
+}
+
+describe("buildEvalJsonAsyncKickoffCode", () => {
+  it("registers the nonce, starts the awaited code, and returns immediately", () => {
+    const frame = createEvalJsonFrame();
+    const code = buildEvalJsonAsyncKickoffCode("app.foo()", frame, "nonce-1");
+
+    expect(code).toContain(`globalThis.${REGISTRY}`);
+    expect(code).toContain(JSON.stringify("nonce-1"));
+    expect(code).toContain("{state:'pending'}");
     expect(code).toContain("await (0,eval)(__obsidianE2ECode)");
-    // Reuses the shared serializer/decoder envelope.
-    expect(code).toContain("__obsidianE2ESerialize");
-    expect(code).toContain("JSON.stringify({ok:true,value:");
+    expect(code).toContain(JSON.stringify(frame.begin));
+    expect(code).toContain(JSON.stringify(frame.end));
   });
 
   it("wraps the caller code so a top-level await parses", () => {
     // Indirect eval treats its argument as a script, where a bare `await` would
     // be a SyntaxError; the wrapper turns it into an async arrow expression body.
-    const code = buildEvalJsonAsyncCode("await load()", createEvalJsonFrame());
+    const code = buildEvalJsonAsyncKickoffCode("await load()", createEvalJsonFrame(), "n");
 
     expect(code).toContain(JSON.stringify("(async()=>(await load()))()"));
   });
-
-  it("embeds the per-call frame markers around the envelope", () => {
-    const frame = createEvalJsonFrame();
-    const code = buildEvalJsonAsyncCode("app.foo()", frame);
-
-    expect(code).toContain(JSON.stringify(frame.begin));
-    expect(code).toContain(JSON.stringify(frame.end));
-  });
 });
 
-// Exercises the generated code in a real JS engine (the stubbed transport tests
-// above never execute it) so the top-level-await path cannot regress silently.
-describe("buildEvalJsonAsyncCode executed", () => {
-  const evalGenerated = async <T>(userCode: string): Promise<T> => {
-    const frame = createEvalJsonFrame();
-    const raw = await (0, eval)(buildEvalJsonAsyncCode(userCode, frame));
-    return parseEvalJsonEnvelope<T>(raw, frame);
-  };
+describe("runEvalJsonAsync", () => {
+  it("resolves the awaited value and cleans up the registry entry", async () => {
+    const { commands, dev } = createInAppEmulator();
 
-  it("runs a top-level-await body and returns the resolved value", async () => {
-    await expect(evalGenerated("await Promise.resolve({ count: 2 })")).resolves.toEqual({
-      count: 2,
-    });
+    await expect(
+      runEvalJsonAsync(dev, "await Promise.resolve({ count: 2, items: [1, 2] })"),
+    ).resolves.toEqual({ count: 2, items: [1, 2] });
+
+    // kickoff + poll + cleanup, every command a short read/write.
+    expect(commands.length).toBeGreaterThanOrEqual(3);
+    expect(commands.at(-1)?.code).toContain("delete registry[");
+    expect(Object.keys(registryEntries())).toHaveLength(0);
   });
 
-  it("runs a promise-returning expression", async () => {
-    await expect(evalGenerated("Promise.resolve('ready')")).resolves.toBe("ready");
+  it("resolves an undefined result through the sentinel", async () => {
+    const { dev } = createInAppEmulator();
+
+    await expect(runEvalJsonAsync(dev, "await Promise.resolve(undefined)")).resolves.toBe(
+      undefined,
+    );
   });
 
-  it("runs an async IIFE expression", async () => {
-    await expect(evalGenerated("(async () => 'done')()")).resolves.toBe("done");
-  });
+  it("surfaces a rejected promise as a DevEvalError with the remote stack", async () => {
+    const { dev } = createInAppEmulator();
 
-  it("surfaces a rejected promise as a DevEvalError", async () => {
-    const error = await evalGenerated("Promise.reject(new TypeError('nope'))").catch(
+    const error = await runEvalJsonAsync(dev, "Promise.reject(new TypeError('nope'))").catch(
       (thrown) => thrown,
     );
 
     expect(error).toBeInstanceOf(DevEvalError);
     expect((error as DevEvalError).message).toBe("Failed to evaluate Obsidian code: nope");
+    expect((error as DevEvalError).remote.name).toBe("TypeError");
+    expect((error as DevEvalError).remote.stack).toContain("TypeError: nope");
   });
-});
 
-describe("runEvalJsonAsync", () => {
-  it("resolves the awaited value from a success envelope", async () => {
-    const dev = stubDev((code) =>
-      frameEvalPayload(code, JSON.stringify({ ok: true, value: { count: 2, items: [1, 2] } })),
+  it("stores a serialization failure as an error envelope at completion time", async () => {
+    const { dev } = createInAppEmulator();
+
+    await expect(runEvalJsonAsync(dev, "Promise.resolve(() => 1)")).rejects.toThrowError(
+      /Cannot serialize function/,
     );
+  });
 
-    await expect(runEvalJsonAsync(dev, "await load()")).resolves.toEqual({
-      count: 2,
-      items: [1, 2],
+  it("recovers the result when the kickoff reply is lost (delivered, reply dropped)", async () => {
+    (globalThis as Record<string, unknown>).__runs = 0;
+    const { dev } = createInAppEmulator(({ index }) => (index === 0 ? "drop-reply" : undefined));
+
+    await expect(
+      runEvalJsonAsync(dev, "(globalThis.__runs++, await Promise.resolve('recovered'))"),
+    ).resolves.toBe("recovered");
+    expect((globalThis as Record<string, unknown>).__runs).toBe(1);
+    delete (globalThis as Record<string, unknown>).__runs;
+  });
+
+  it("recovers when a poll reply is lost", async () => {
+    const { dev } = createInAppEmulator(({ index }) => (index === 1 ? "drop-reply" : undefined));
+
+    await expect(runEvalJsonAsync(dev, "await Promise.resolve('polled')")).resolves.toBe("polled");
+  });
+
+  it("fails with reason 'still-pending' when the promise never settles", async () => {
+    const { dev } = createInAppEmulator();
+
+    const error = await runEvalJsonAsync(dev, "new Promise(() => {})", {
+      timeoutMs: 450,
+    }).catch((thrown) => thrown);
+
+    expect(error).toBeInstanceOf(DevEvalAsyncError);
+    expect((error as DevEvalAsyncError).reason).toBe("still-pending");
+    // The operation is still registered; the message names the nonce for inspection.
+    expect((error as DevEvalAsyncError).message).toContain((error as DevEvalAsyncError).nonce);
+  });
+
+  it("fails with reason 'context-reset' when the registry vanishes after confirmation", async () => {
+    const { dev } = createInAppEmulator(({ index }) => {
+      if (index === 1) {
+        // Simulate an app/vault reload wiping the renderer between commands.
+        delete (globalThis as Record<string, unknown>)[REGISTRY];
+      }
+      return undefined;
     });
+
+    const error = await runEvalJsonAsync(dev, "new Promise(() => {})").catch((thrown) => thrown);
+
+    expect(error).toBeInstanceOf(DevEvalAsyncError);
+    expect((error as DevEvalAsyncError).reason).toBe("context-reset");
   });
 
-  it("decodes the undefined sentinel", async () => {
-    const dev = stubDev((code) =>
-      frameEvalPayload(
-        code,
-        JSON.stringify({ ok: true, value: { done: { __obsidianE2EType: "undefined" } } }),
-      ),
+  it("fails with reason 'ambiguous-delivery' and never reruns when kickoff delivery is unknown", async () => {
+    (globalThis as Record<string, unknown>).__runs = 0;
+    // The kickoff times out without ever executing; polls legitimately find nothing.
+    const dev: Pick<ObsidianDevHandle, "evalRaw"> = {
+      async evalRaw(code) {
+        if (code.includes("{state:'pending'}")) {
+          throw new ObsidianCommandTimeoutError("obsidian", ["eval"], 10);
+        }
+        return (0, eval)(code) as string;
+      },
+    };
+
+    const error = await runEvalJsonAsync(dev, "globalThis.__runs++", { timeoutMs: 450 }).catch(
+      (thrown) => thrown,
     );
 
-    await expect(runEvalJsonAsync(dev, "await noop()")).resolves.toEqual({ done: undefined });
+    expect(error).toBeInstanceOf(DevEvalAsyncError);
+    expect((error as DevEvalAsyncError).reason).toBe("ambiguous-delivery");
+    expect((globalThis as Record<string, unknown>).__runs).toBe(0);
+    delete (globalThis as Record<string, unknown>).__runs;
   });
 
-  it("surfaces a thrown error with message and remote stack", async () => {
-    const dev = stubDev((code) =>
-      frameEvalPayload(
-        code,
-        JSON.stringify({
-          ok: false,
-          error: { message: "boom", name: "TypeError", stack: "TypeError: boom\n    at eval" },
-        }),
-      ),
+  it("reports 'ambiguous-delivery' with the connect failure as cause when the CLI never connects", async () => {
+    (globalThis as Record<string, unknown>).__runs = 0;
+    const { dev } = createInAppEmulator(() => "fail-undelivered");
+
+    const error = await runEvalJsonAsync(dev, "globalThis.__runs++", { timeoutMs: 350 }).catch(
+      (thrown) => thrown,
     );
 
-    const error = await runEvalJsonAsync(dev, "await fail()").catch((thrown) => thrown);
+    expect(error).toBeInstanceOf(DevEvalAsyncError);
+    expect((error as DevEvalAsyncError).reason).toBe("ambiguous-delivery");
+    expect((error as DevEvalAsyncError).message).toContain(
+      "kickoff command failed or its reply was lost",
+    );
+    expect((error as DevEvalAsyncError).causeError).toBeInstanceOf(ObsidianCommandError);
+    // The kickoff is never resent, so the code cannot have run.
+    expect((globalThis as Record<string, unknown>).__runs).toBe(0);
+    delete (globalThis as Record<string, unknown>).__runs;
+  });
 
-    expect(error).toBeInstanceOf(DevEvalError);
-    expect((error as DevEvalError).message).toBe("Failed to evaluate Obsidian code: boom");
-    expect((error as DevEvalError).remote.stack).toBe("TypeError: boom\n    at eval");
-    expect((error as DevEvalError).stack).toContain("TypeError: boom\n    at eval");
+  it("parses kickoff and poll replies surrounded by plugin log noise", async () => {
+    const emulator = createInAppEmulator();
+    const dev: Pick<ObsidianDevHandle, "evalRaw"> = {
+      async evalRaw(code, execOptions) {
+        const output = await emulator.dev.evalRaw(code, execOptions);
+        return `QuickAdd: (LOG) Applying template\n${output}\nMetaEdit: trailing logger output`;
+      },
+    };
+
+    await expect(
+      runEvalJsonAsync(dev, "await Promise.resolve({ path: 'note.md' })"),
+    ).resolves.toEqual({ path: "note.md" });
   });
 });
 
-// Regression for https://github.com/chhoumann/obsidian-e2e/issues/18: the eval
-// channel is shared with whatever the plugin prints while the evaluated code
-// runs (e.g. "QuickAdd: ..." notices), which used to corrupt the JSON envelope.
-describe("runEvalJsonAsync with plugin output on the eval channel", () => {
-  it("parses the envelope surrounded by plugin log noise", async () => {
-    const dev = stubDev((code) =>
-      [
-        "QuickAdd: (LOG) Applying template to active file",
-        frameEvalPayload(code, JSON.stringify({ ok: true, value: { path: "note.md" } })),
-        "MetaEdit: trailing logger output",
-      ].join("\n"),
-    );
+describe("buildEvalJsonAsyncPollCode / buildEvalJsonAsyncCleanupCode", () => {
+  it("reads and deletes exactly the nonce entry", () => {
+    (globalThis as Record<string, unknown>)[REGISTRY] = {
+      keep: { state: "pending" },
+      mine: { envelope: { ok: true, value: 1 }, state: "done" },
+    };
 
-    await expect(runEvalJsonAsync(dev, "await apply()")).resolves.toEqual({ path: "note.md" });
-  });
+    expect((0, eval)(buildEvalJsonAsyncPollCode("mine"))).toEqual({
+      envelope: { ok: true, value: 1 },
+      state: "done",
+    });
+    expect((0, eval)(buildEvalJsonAsyncPollCode("missing"))).toBe(null);
 
-  it("parses an error envelope surrounded by plugin log noise", async () => {
-    const dev = stubDev((code) =>
-      [
-        "QuickAdd: (ERROR) template failed",
-        frameEvalPayload(
-          code,
-          JSON.stringify({ ok: false, error: { message: "boom", name: "Error" } }),
-        ),
-      ].join("\n"),
-    );
-
-    await expect(runEvalJsonAsync(dev, "await fail()")).rejects.toThrowError(
-      "Failed to evaluate Obsidian code: boom",
-    );
-  });
-
-  it("parses when the serialized value itself contains the frame marker text", async () => {
-    const frame = createEvalJsonFrame();
-    const value = { echo: `${frame.begin} inside ${frame.end}` };
-    const raw = `noise\n${frame.begin}${JSON.stringify({ ok: true, value })}${frame.end}\n`;
-
-    expect(parseEvalJsonEnvelope(raw, frame)).toEqual(value);
-  });
-
-  it("reports a clear error when the framed envelope is missing entirely", async () => {
-    const dev = stubDev(() => "QuickAdd: only log output, no envelope");
-
-    await expect(runEvalJsonAsync(dev, "await apply()")).rejects.toThrowError(
-      /did not contain the framed JSON result envelope/,
-    );
+    expect((0, eval)(buildEvalJsonAsyncCleanupCode("mine"))).toBe(true);
+    expect(Object.keys(registryEntries())).toEqual(["keep"]);
   });
 });
 
 describe("obsidian.dev.evalJsonAsync", () => {
-  it("passes the async builder output through evalRaw and decodes the envelope", async () => {
+  it("runs the kickoff-and-poll protocol through the client transport", async () => {
     const evalCodes: string[] = [];
     const transport: CommandTransport = async (request) => {
       if (request.argv[0] === "--help") {
@@ -199,11 +290,8 @@ describe("obsidian.dev.evalJsonAsync", () => {
       if (command === "eval") {
         const code = args.code ?? "";
         evalCodes.push(code);
-        return createExecResult(
-          request.bin,
-          request.argv,
-          `${frameEvalPayload(code, JSON.stringify({ ok: true, value: "ready" }))}\n`,
-        );
+        const output = (await (0, eval)(code)) as string;
+        return createExecResult(request.bin, request.argv, `${output}\n`);
       }
 
       throw new Error(`Unhandled transport request: ${request.argv.join(" ")}`);
@@ -214,7 +302,56 @@ describe("obsidian.dev.evalJsonAsync", () => {
     await expect(
       obsidian.dev.evalJsonAsync<string>("await Promise.resolve('ready')"),
     ).resolves.toBe("ready");
-    expect(evalCodes).toHaveLength(1);
+
+    // kickoff + at least one poll + cleanup - never a single held command.
+    expect(evalCodes.length).toBeGreaterThanOrEqual(3);
     expect(evalCodes[0]).toContain("await (0,eval)(__obsidianE2ECode)");
+    expect(evalCodes[1]).toContain(REGISTRY);
+  });
+
+  it("propagates default env/cwd to every protocol command and honors the default timeout as deadline", async () => {
+    const seen: { cwd?: string; env?: NodeJS.ProcessEnv; timeoutMs?: number }[] = [];
+    const transport: CommandTransport = async (request) => {
+      const [, command, ...rest] = request.argv;
+      if (command === "eval") {
+        seen.push({ cwd: request.cwd, env: request.env, timeoutMs: request.timeoutMs });
+        const code = rest.find((entry) => entry.startsWith("code="))?.slice(5) ?? "";
+        const output = (await (0, eval)(code)) as string;
+        return createExecResult(request.bin, request.argv, `${output}\n`);
+      }
+      return createExecResult(request.bin, request.argv, "");
+    };
+
+    const obsidian = createObsidianClient({
+      defaultExecOptions: { cwd: "/work", env: { HOME: "/private-home" }, timeoutMs: 700 },
+      transport,
+      vault: "dev",
+    });
+
+    const error = await obsidian.dev
+      .evalJsonAsync("new Promise(() => {})")
+      .catch((thrown) => thrown);
+
+    // The default timeoutMs bounds the whole protocol, not one command.
+    expect(error).toBeInstanceOf(DevEvalAsyncError);
+    expect((error as DevEvalAsyncError).reason).toBe("still-pending");
+    expect(seen.length).toBeGreaterThanOrEqual(2);
+    for (const command of seen) {
+      expect(command.cwd).toBe("/work");
+      expect(command.env?.HOME).toBe("/private-home");
+      expect(command.timeoutMs).toBeLessThanOrEqual(700);
+    }
+  });
+});
+
+describe("frameEvalPayload compatibility", () => {
+  it("still frames synchronous evalJson payloads for stubbed transports", () => {
+    const frame = createEvalJsonFrame();
+    const framed = frameEvalPayload(
+      `prefix ${frame.begin} suffix`,
+      JSON.stringify({ ok: true, value: 1 }),
+    );
+
+    expect(parseEvalJsonEnvelope<number>(framed, frame)).toBe(1);
   });
 });


### PR DESCRIPTION
`evalJsonAsync` held a single `obsidian eval` CLI command open for the whole lifetime of the awaited promise, and that command's reply was the only carrier of the result. Investigated the transport end-to-end (native `obsidian-cli` → `~/.obsidian-cli.sock` → Electron main `executeJavaScript` → renderer `handleCli` which `await`s `window.eval(code)`) and reproduced two unrecoverable losses against the real CLI socket:

- a client-side timeout kill while the operation completes in-app (the QuickAdd A06 artifact shape: merged note, empty diagnostics, no reply), and
- a vault reload mid-eval, which orphans the pending `executeJavaScript` promise so the CLI hangs indefinitely.

Mild concurrency alone dropped nothing; load shows up as latency, which the old single-command design converts into loss via the timeout kill.

`evalJsonAsync` (same API) now runs a kickoff-and-poll protocol: a short kickoff command - sent exactly once, ever - starts the operation and records its eventual `{ ok, value }` envelope under a per-operation nonce inside the app; short idempotent poll reads retrieve it. A lost reply is recovered by reading again, and because the kickoff is never resent, the evaluated code cannot run twice. `timeoutMs` is now the overall deadline for the awaited result; each internal CLI command runs on its own short budget. Consumer-suite fire-and-poll workarounds are obsolete.

Irrecoverable states throw the new `DevEvalAsyncError` whose `reason` names the observed transport state instead of a generic 30s timeout: `ambiguous-delivery` (kickoff failed or unacknowledged, no in-app record; cause attached), `context-reset` (confirmed running, then the renderer was wiped), `still-pending` (promise not settled by the deadline). The transport throws a typed `ObsidianCommandTimeoutError`, and error classes are exported from the package root.

Alternatives considered: a separate polled variant next to the old behavior (rejected: two await paths, and the old semantics have no surviving use case) and a resend path gated on CLI stderr signatures (rejected: message text is not a structural delivery acknowledgement; single-send keeps exactly-once literal).

Verified live against a self-provisioned isolated instance through the real CLI socket: a 12s operation resolves exactly-once through short polls; reload mid-operation yields `context-reset` where the raw transport previously hung forever; a never-settling promise yields `still-pending`; an unreachable app yields `ambiguous-delivery`. Unit suite emulates the in-app side by executing the generated code against a real `globalThis` registry (lost kickoff/poll replies, connect failures, exactly-once counters).

Review focus: the terminal-state ordering in `runEvalJsonAsync` (unconfirmed-null vs confirmed-null) and the `timeoutMs` semantics change.

Fixes #21