### PR TITLE
fix(runner): force settingsPopoutWindow off in provisioned vaults

### DIFF
--- a/.changeset/settings-popout-window-off.md
+++ b/.changeset/settings-popout-window-off.md
@@ -1,0 +1,5 @@
+---
+"obsidian-e2e": patch
+---
+
+Provisioned vaults now force `settingsPopoutWindow: false` in `app.json`, so Obsidian 1.13+ opens Settings embedded in the main window instead of the new default popout window. The flag is re-applied on every provision (other keys are preserved), so vaults provisioned before this release are corrected on their next run.

--- a/.changeset/settings-popout-window-off.md
+++ b/.changeset/settings-popout-window-off.md
@@ -2,4 +2,8 @@
 "obsidian-e2e": patch
 ---
 
-Provisioned vaults now force `settingsPopoutWindow: false` in `app.json`, so Obsidian 1.13+ opens Settings embedded in the main window instead of the new default popout window. The flag is re-applied on every provision (other keys are preserved), so vaults provisioned before this release are corrected on their next run.
+Provisioned vaults now enforce harness-invariant `app.json` keys on every provision (other keys are preserved, so existing vaults are corrected on their next run):
+
+- `settingsPopoutWindow: false` - Obsidian 1.13+ defaults to opening Settings in a separate popout window, outside the main window the harness drives.
+- `spellcheck: false` - OS-dictionary squiggles added per-machine variance to screenshots and failure artifacts.
+- `trashOption: "local"` - the "system" default leaked UI-driven test deletions into the OS trash instead of the disposable vault's `.trash`.

--- a/src/runner/provision.ts
+++ b/src/runner/provision.ts
@@ -164,11 +164,27 @@ export function provisionShellExports(
 }
 
 /**
- * Seed `app.json`, forcing `settingsPopoutWindow: false` while preserving every
- * other existing key. Obsidian 1.13+ defaults the flag to true, which opens
- * Settings in a separate popout window - outside the main window the harness
- * drives and captures. Re-applied on every provision (not write-if-missing) so
- * vaults provisioned before that Obsidian default existed are corrected on
+ * Vault `app.json` keys the harness enforces, overriding both Obsidian's
+ * defaults and any drifted vault state:
+ * - `settingsPopoutWindow: false` - Obsidian 1.13+ defaults to opening
+ *   Settings in a separate popout window, outside the main window the harness
+ *   drives and captures.
+ * - `spellcheck: false` - the default (true) underlines typed test content
+ *   using OS dictionaries and language settings, adding per-machine variance
+ *   to screenshots and failure artifacts.
+ * - `trashOption: "local"` - the default ("system") sends UI-driven deletes
+ *   to the OS trash, leaking disposable test state outside the vault.
+ */
+export const ENFORCED_APP_CONFIG = {
+  settingsPopoutWindow: false,
+  spellcheck: false,
+  trashOption: "local",
+} as const;
+
+/**
+ * Seed `app.json`, forcing {@link ENFORCED_APP_CONFIG} while preserving every
+ * other existing key. Re-applied on every provision (not write-if-missing) so
+ * vaults provisioned before these Obsidian defaults existed are corrected on
  * their next run.
  */
 async function writeAppJson(appJsonPath: string): Promise<void> {
@@ -183,7 +199,7 @@ async function writeAppJson(appJsonPath: string): Promise<void> {
       // Unparseable app.json in a disposable E2E vault: reseed it.
     }
   }
-  await writeJson(appJsonPath, { ...existing, settingsPopoutWindow: false });
+  await writeJson(appJsonPath, { ...existing, ...ENFORCED_APP_CONFIG });
 }
 
 async function assertRequiredPluginFiles(

--- a/src/runner/provision.ts
+++ b/src/runner/provision.ts
@@ -71,12 +71,12 @@ export async function provisionVault(
   const pluginPath = path.join(obsidianPath, "plugins", config.pluginId);
 
   await fs.mkdir(pluginPath, { recursive: true });
-  await writeJsonIfMissing(path.join(obsidianPath, "app.json"), {});
+  await writeAppJson(path.join(obsidianPath, "app.json"));
   await writeJsonIfMissing(path.join(obsidianPath, "appearance.json"), {});
   await writeJsonIfMissing(path.join(obsidianPath, "core-plugins.json"), []);
-  // community-plugins.json is written unconditionally (every other config is
-  // write-if-missing): it keeps the plugin enabled even if a prior provision or a
-  // manual edit dropped it. The vault is disposable E2E state, never user data.
+  // community-plugins.json is written unconditionally: it keeps the plugin
+  // enabled even if a prior provision or a manual edit dropped it. The vault is
+  // disposable E2E state, never user data.
   await writeJson(path.join(obsidianPath, "community-plugins.json"), [config.pluginId]);
   await writeJsonIfMissing(
     path.join(obsidianPath, "workspace.json"),
@@ -161,6 +161,29 @@ export function provisionShellExports(
     );
   }
   return toShellExports(exports);
+}
+
+/**
+ * Seed `app.json`, forcing `settingsPopoutWindow: false` while preserving every
+ * other existing key. Obsidian 1.13+ defaults the flag to true, which opens
+ * Settings in a separate popout window - outside the main window the harness
+ * drives and captures. Re-applied on every provision (not write-if-missing) so
+ * vaults provisioned before that Obsidian default existed are corrected on
+ * their next run.
+ */
+async function writeAppJson(appJsonPath: string): Promise<void> {
+  let existing: Record<string, unknown> = {};
+  if (await pathExists(appJsonPath)) {
+    try {
+      const parsed: unknown = JSON.parse(await fs.readFile(appJsonPath, "utf8"));
+      if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+        existing = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Unparseable app.json in a disposable E2E vault: reseed it.
+    }
+  }
+  await writeJson(appJsonPath, { ...existing, settingsPopoutWindow: false });
 }
 
 async function assertRequiredPluginFiles(

--- a/tests/runner/provision.test.ts
+++ b/tests/runner/provision.test.ts
@@ -236,6 +236,66 @@ for (const scenario of scenarios) {
   });
 }
 
+describe("app.json settings window enforcement", () => {
+  const config = makeConfig();
+
+  async function provisionInto(root: string, worktree: string) {
+    const options = resolveProvisionOptions(
+      { root, vault: `${config.pluginId}-app-json`, worktree },
+      config,
+    );
+    const result = await provisionVault(options, config);
+    return path.join(result.vaultPath, ".obsidian", "app.json");
+  }
+
+  test("seeds app.json with settingsPopoutWindow disabled", async () => {
+    const root = await createTempDir(tempDirectories, "provision-root-");
+    const worktree = await createTempDir(tempDirectories, "provision-worktree-");
+    await seedWorktree(worktree, config.pluginArtifacts, "a");
+
+    const appJsonPath = await provisionInto(root, worktree);
+
+    expect(JSON.parse(await fs.readFile(appJsonPath, "utf8"))).toEqual({
+      settingsPopoutWindow: false,
+    });
+  });
+
+  test("re-forces settingsPopoutWindow false on reprovision, preserving other keys", async () => {
+    // Vaults provisioned before Obsidian 1.13 introduced the popout default
+    // carry an app.json without the flag (or with it re-enabled); the next
+    // provision must correct it without dropping unrelated config.
+    const root = await createTempDir(tempDirectories, "provision-root-");
+    const worktree = await createTempDir(tempDirectories, "provision-worktree-");
+    await seedWorktree(worktree, config.pluginArtifacts, "a");
+
+    const appJsonPath = await provisionInto(root, worktree);
+    await fs.writeFile(
+      appJsonPath,
+      JSON.stringify({ settingsPopoutWindow: true, showLineNumber: true }),
+    );
+    await provisionInto(root, worktree);
+
+    expect(JSON.parse(await fs.readFile(appJsonPath, "utf8"))).toEqual({
+      settingsPopoutWindow: false,
+      showLineNumber: true,
+    });
+  });
+
+  test("reseeds an unparseable app.json instead of failing", async () => {
+    const root = await createTempDir(tempDirectories, "provision-root-");
+    const worktree = await createTempDir(tempDirectories, "provision-worktree-");
+    await seedWorktree(worktree, config.pluginArtifacts, "a");
+
+    const appJsonPath = await provisionInto(root, worktree);
+    await fs.writeFile(appJsonPath, "{not json");
+    await provisionInto(root, worktree);
+
+    expect(JSON.parse(await fs.readFile(appJsonPath, "utf8"))).toEqual({
+      settingsPopoutWindow: false,
+    });
+  });
+});
+
 describe("linkPluginFile reconcile paths", () => {
   test("is a no-op when the correct symlink already exists", async () => {
     const dir = await createTempDir(tempDirectories, "link-");

--- a/tests/runner/provision.test.ts
+++ b/tests/runner/provision.test.ts
@@ -236,7 +236,7 @@ for (const scenario of scenarios) {
   });
 }
 
-describe("app.json settings window enforcement", () => {
+describe("app.json enforced config", () => {
   const config = makeConfig();
 
   async function provisionInto(root: string, worktree: string) {
@@ -248,7 +248,7 @@ describe("app.json settings window enforcement", () => {
     return path.join(result.vaultPath, ".obsidian", "app.json");
   }
 
-  test("seeds app.json with settingsPopoutWindow disabled", async () => {
+  test("seeds app.json with exactly the enforced config", async () => {
     const root = await createTempDir(tempDirectories, "provision-root-");
     const worktree = await createTempDir(tempDirectories, "provision-worktree-");
     await seedWorktree(worktree, config.pluginArtifacts, "a");
@@ -257,13 +257,16 @@ describe("app.json settings window enforcement", () => {
 
     expect(JSON.parse(await fs.readFile(appJsonPath, "utf8"))).toEqual({
       settingsPopoutWindow: false,
+      spellcheck: false,
+      trashOption: "local",
     });
   });
 
-  test("re-forces settingsPopoutWindow false on reprovision, preserving other keys", async () => {
-    // Vaults provisioned before Obsidian 1.13 introduced the popout default
-    // carry an app.json without the flag (or with it re-enabled); the next
-    // provision must correct it without dropping unrelated config.
+  test("re-forces enforced keys on reprovision, preserving other keys", async () => {
+    // Vaults provisioned before these Obsidian defaults existed carry an
+    // app.json without the keys (or with them drifted back to the Obsidian
+    // defaults); the next provision must correct every enforced key without
+    // dropping unrelated config.
     const root = await createTempDir(tempDirectories, "provision-root-");
     const worktree = await createTempDir(tempDirectories, "provision-worktree-");
     await seedWorktree(worktree, config.pluginArtifacts, "a");
@@ -271,12 +274,19 @@ describe("app.json settings window enforcement", () => {
     const appJsonPath = await provisionInto(root, worktree);
     await fs.writeFile(
       appJsonPath,
-      JSON.stringify({ settingsPopoutWindow: true, showLineNumber: true }),
+      JSON.stringify({
+        settingsPopoutWindow: true,
+        spellcheck: true,
+        trashOption: "system",
+        showLineNumber: true,
+      }),
     );
     await provisionInto(root, worktree);
 
     expect(JSON.parse(await fs.readFile(appJsonPath, "utf8"))).toEqual({
       settingsPopoutWindow: false,
+      spellcheck: false,
+      trashOption: "local",
       showLineNumber: true,
     });
   });
@@ -292,6 +302,8 @@ describe("app.json settings window enforcement", () => {
 
     expect(JSON.parse(await fs.readFile(appJsonPath, "utf8"))).toEqual({
       settingsPopoutWindow: false,
+      spellcheck: false,
+      trashOption: "local",
     });
   });
 });


### PR DESCRIPTION
Provisioned E2E vaults now enforce harness-invariant keys in the vault's `app.json`:

- `settingsPopoutWindow: false` - Obsidian 1.13 added an "open Settings in a new window" option and defaulted it to on. Since the harness seeded `app.json` as `{}`, every provisioned vault opened Settings in a separate Electron window, outside the main window the harness drives and captures.
- `spellcheck: false` - Obsidian's default (true) underlines typed test content using OS dictionaries and language settings, adding per-machine variance to screenshots and failure artifacts.
- `trashOption: "local"` - the "system" default sends UI-driven test deletions to the OS trash, leaking disposable test state outside the vault (and making delete behavior unassertable).

The seed is a merge-write applied on every provision (like `community-plugins.json`), rather than write-if-missing: other `app.json` keys are preserved, enforced keys are always forced back, and an unparseable `app.json` is reseeded. Vaults provisioned before this release self-heal on their next `run`/`ensure` with no manual cleanup. The enforced set is exported as `ENFORCED_APP_CONFIG`.

All other vault defaults deliberately stay untouched (e.g. `promptDelete`, editor and link settings): E2E vaults should mirror what a real user's fresh vault does unless a default breaks isolation or determinism.

Verified with the built CLI against a scratch worktree: a fresh provision seeds exactly the enforced config, and reprovisioning a vault whose keys drifted back to Obsidian defaults corrects them while keeping unrelated keys intact.

Includes a patch changeset; consumers on `^0.8.2` pick this up automatically once published.