### PR TITLE
fix(core): recoverable exec() dispatch so lost CLI replies stop hanging 30s (#25)

### DIFF
--- a/.changeset/recoverable-exec-dispatch.md
+++ b/.changeset/recoverable-exec-dispatch.md
@@ -14,20 +14,26 @@ until the 30s transport kill and flaked consumer suites.
 `exec()` now runs a recoverable dispatch protocol: a one-time shim wrapped
 around the in-app CLI dispatcher intercepts a synthetic dispatch verb whose
 payload carries the real command argv, a per-call nonce, and the shim
-generation. The shim records the reply under the nonce before dispatching,
-dedups repeated nonces, and refuses payloads pinned to a previous generation,
-so lost replies are recovered by short idempotent polls and recovery can never
-double-execute a non-idempotent command (`quickadd:run` stays exactly-once).
+generation. Lost replies are recovered by short idempotent polls, and recovery
+can never double-execute a non-idempotent command (`quickadd:run` stays
+exactly-once) because a resend requires positive proof of non-execution: the
+shim records the reply under the nonce before dispatching and dedups repeated
+nonces, refuses payloads pinned to a previous generation, and any reply that
+cannot be positively identified (e.g. the frame-disposal error Obsidian's main
+process serves when a renderer teardown races a request) counts as unknown
+fate - never as proof the command did not run.
 Handlers see their exact original argv; recovered results are byte-identical
 to the direct CLI output. Everything built on `exec()` - `dev.eval`,
 `dev.evalJson`, `command(id).run()`, `plugin(id).reload()` - gains the same
 recovery automatically.
 
 On the recoverable path `timeoutMs` is now the overall deadline for the
-command's result rather than a single process budget. Context-destroying verbs
-(`reload`, `restart`, `plugins:restrict`, `dev:mobile`) and custom transports
-keep the direct single-shot path; `ExecOptions.recoverable` overrides either
-default. Irrecoverable states throw the new `ObsidianCommandDispatchError`
-whose `reason` names the precise transport state (`ambiguous-delivery`,
-`context-reset`, `still-pending`, `undelivered`), exported from the package
-root.
+command's result rather than a single process budget, and timeouts surface as
+the new `ObsidianCommandDispatchError` (with the underlying
+`ObsidianCommandTimeoutError` attached as `causeError`) whose `reason` names
+the precise transport state (`ambiguous-delivery`, `context-reset`,
+`still-pending`, `undelivered`), exported from the package root.
+Context-destroying verbs (`reload`, `restart`, `plugins:restrict`,
+`dev:mobile`, and `command` with `app:reload`/`app:quit`) and custom
+transports keep the direct single-shot path; `ExecOptions.recoverable`
+overrides the transport default.

--- a/.changeset/recoverable-exec-dispatch.md
+++ b/.changeset/recoverable-exec-dispatch.md
@@ -1,0 +1,33 @@
+---
+"obsidian-e2e": minor
+---
+
+`exec()` no longer hangs for the full transport timeout when the Obsidian
+CLI's single-shot reply is lost (#25). Every CLI reply crosses the app's
+main-to-renderer `executeJavaScript` bridge exactly once, and that bridge
+loses or delays messages under suite load (reproduced live: a `plugin:reload`
+completed in-app in 11ms and its reply never arrived; an eval request was
+delayed 13.7s while neighboring commands were instant). Obsidian's CLI server
+has no timeout or retry around the bridge, so a lost reply stalled the client
+until the 30s transport kill and flaked consumer suites.
+
+`exec()` now runs a recoverable dispatch protocol: a one-time shim wrapped
+around the in-app CLI dispatcher intercepts a synthetic dispatch verb whose
+payload carries the real command argv, a per-call nonce, and the shim
+generation. The shim records the reply under the nonce before dispatching,
+dedups repeated nonces, and refuses payloads pinned to a previous generation,
+so lost replies are recovered by short idempotent polls and recovery can never
+double-execute a non-idempotent command (`quickadd:run` stays exactly-once).
+Handlers see their exact original argv; recovered results are byte-identical
+to the direct CLI output. Everything built on `exec()` - `dev.eval`,
+`dev.evalJson`, `command(id).run()`, `plugin(id).reload()` - gains the same
+recovery automatically.
+
+On the recoverable path `timeoutMs` is now the overall deadline for the
+command's result rather than a single process budget. Context-destroying verbs
+(`reload`, `restart`, `plugins:restrict`, `dev:mobile`) and custom transports
+keep the direct single-shot path; `ExecOptions.recoverable` overrides either
+default. Irrecoverable states throw the new `ObsidianCommandDispatchError`
+whose `reason` names the precise transport state (`ambiguous-delivery`,
+`context-reset`, `still-pending`, `undelivered`), exported from the package
+root.

--- a/README.md
+++ b/README.md
@@ -946,6 +946,50 @@ Hand-rolled fire-and-poll loops (a `window` global plus repeated short
 `evalJson` reads) are obsolete: `evalJsonAsync` is that pattern, managed by the
 package.
 
+### How `exec()` recovers lost CLI replies
+
+Every CLI command's reply crosses Obsidian's main-to-renderer bridge exactly
+once, and that bridge loses or delays messages under suite load - a command can
+complete in-app in milliseconds while its reply never reaches the CLI client,
+which then hangs until the transport kills it (#25). `exec()` therefore wraps
+commands in a dispatch protocol: a one-time shim around the in-app CLI
+dispatcher records each command's reply under a per-call nonce before running
+it, so a lost reply is recovered by short idempotent poll reads instead of
+timing out. The shim dedups repeated nonces and refuses payloads pinned to a
+previous shim generation (an app reload), so a command is never executed twice
+by recovery - `quickadd:run`-style non-idempotent commands stay exactly-once.
+The command's handler sees its exact original argv, and the recovered
+`ExecResult` is byte-identical to the direct CLI output (including exit code 0
+for `Error: ...` replies).
+
+The happy path stays a single CLI roundtrip. On the recoverable path,
+`timeoutMs` is the overall deadline for the command's result; the dispatch
+attempt and the internal polls run on their own short budgets, so a
+long-running command no longer dies with the 30s socket hold either.
+Everything built on `exec()` - `dev.eval`, `dev.evalJson`, `command(id).run()`,
+`plugin(id).reload()`, and the `evalJsonAsync` internals - gains the same
+recovery automatically.
+
+Defaults: recoverable on the built-in transport, direct on a custom
+`transport` (a test fake cannot serve the protocol); `reload`, `restart`,
+`plugins:restrict`, and `dev:mobile` always use the direct path because their
+success destroys the renderer context the recovery registry lives in. Override
+per call or via `defaultExecOptions` with `recoverable: true | false`.
+
+When the result cannot be produced, `exec()` throws
+`ObsidianCommandDispatchError` whose `reason` names the precise transport
+state:
+
+- `ambiguous-delivery`: no dispatch attempt was acknowledged and no in-app
+  record appeared; the command may or may not have started, and cannot have
+  run twice.
+- `context-reset`: the renderer context was reset while an attempt was in
+  flight; whether the command executed before the reset is unknowable.
+- `still-pending`: the command is confirmed running in-app but has not settled
+  within the deadline.
+- `undelivered`: the dispatch shim could not be installed; the command was
+  never dispatched and did not run, so retrying is safe.
+
 ## Layer Boundaries
 
 - `vault` stays filesystem-only. If the behavior depends on Obsidian parsing or

--- a/README.md
+++ b/README.md
@@ -955,9 +955,12 @@ which then hangs until the transport kills it (#25). `exec()` therefore wraps
 commands in a dispatch protocol: a one-time shim around the in-app CLI
 dispatcher records each command's reply under a per-call nonce before running
 it, so a lost reply is recovered by short idempotent poll reads instead of
-timing out. The shim dedups repeated nonces and refuses payloads pinned to a
-previous shim generation (an app reload), so a command is never executed twice
-by recovery - `quickadd:run`-style non-idempotent commands stay exactly-once.
+timing out. Recovery never re-sends a command without positive proof it did
+not run: the shim dedups repeated nonces, refuses payloads pinned to a
+previous shim generation (an app reload), and a reply that cannot be
+positively identified counts as unknown fate rather than as proof of
+non-execution. `quickadd:run`-style non-idempotent commands stay
+exactly-once.
 The command's handler sees its exact original argv, and the recovered
 `ExecResult` is byte-identical to the direct CLI output (including exit code 0
 for `Error: ...` replies).
@@ -971,10 +974,15 @@ Everything built on `exec()` - `dev.eval`, `dev.evalJson`, `command(id).run()`,
 recovery automatically.
 
 Defaults: recoverable on the built-in transport, direct on a custom
-`transport` (a test fake cannot serve the protocol); `reload`, `restart`,
-`plugins:restrict`, and `dev:mobile` always use the direct path because their
-success destroys the renderer context the recovery registry lives in. Override
-per call or via `defaultExecOptions` with `recoverable: true | false`.
+`transport` (a test fake cannot serve the protocol - note this also applies to
+transports that merely wrap the built-in one for logging; opt back in with
+`recoverable: true`). `reload`, `restart`, `plugins:restrict`, and
+`dev:mobile` always use the direct path because their success destroys the
+renderer context the recovery registry lives in, as does `command` with the
+context-destroying built-in ids (`app:reload`, `app:quit`); plugin commands
+whose handlers reload the app cannot be enumerated, so route those through
+`recoverable: false` yourself. Override per call or via `defaultExecOptions`
+with `recoverable: true | false`.
 
 When the result cannot be produced, `exec()` throws
 `ObsidianCommandDispatchError` whose `reason` names the precise transport

--- a/src/core/args.ts
+++ b/src/core/args.ts
@@ -5,7 +5,16 @@ export function buildCommandArgv(
   command: string,
   args: Record<string, ObsidianArg> = {},
 ): string[] {
-  const argv = [`vault=${vaultName}`, command];
+  return [`vault=${vaultName}`, command, ...buildArgTokens(args)];
+}
+
+/**
+ * The `key=value` tokens after the command, without the `vault=` prefix - the
+ * shape `window.handleCli` receives in-app (the main process consumes the
+ * vault token before relaying argv).
+ */
+export function buildArgTokens(args: Record<string, ObsidianArg> = {}): string[] {
+  const tokens: string[] = [];
 
   for (const [key, value] of Object.entries(args)) {
     if (value === false || value === null || value === undefined) {
@@ -13,12 +22,12 @@ export function buildCommandArgv(
     }
 
     if (value === true) {
-      argv.push(key);
+      tokens.push(key);
       continue;
     }
 
-    argv.push(`${key}=${String(value)}`);
+    tokens.push(`${key}=${String(value)}`);
   }
 
-  return argv;
+  return tokens;
 }

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1,4 +1,5 @@
 import { buildCommandArgv } from "./args";
+import { createDispatchState, runRecoverableExec } from "./dispatch";
 import { mergeExecOptions } from "./exec-options";
 import { attachClientInternals, createRestoreManager } from "./internals";
 import { createObsidianMetadataHandle } from "../metadata/metadata";
@@ -32,8 +33,21 @@ import type {
 } from "./types";
 import { sleep, waitForValue } from "./wait";
 
+/**
+ * CLI verbs whose success destroys or replaces the renderer context (the only
+ * handlers that call `window.location.reload()` / `app.relaunch()`). Their
+ * replies race their own effect by design, and the dispatch registry dies with
+ * the context, so they always use the direct single-shot path.
+ */
+const NON_RECOVERABLE_COMMANDS = new Set(["dev:mobile", "plugins:restrict", "reload", "restart"]);
+
 export function createObsidianClient(options: CreateObsidianClientOptions): ObsidianClient {
   const transport = options.transport ?? executeCommand;
+  // Recoverable dispatch only means anything against the real CLI: a custom
+  // transport (a test fake) would receive dispatch-verb argv it cannot serve,
+  // so it defaults to the direct path unless `recoverable` opts in.
+  const recoverableByDefault = !options.transport;
+  const dispatchState = createDispatchState();
   const defaultExecOptions = options.defaultExecOptions;
   const waitDefaults = {
     intervalMs: options.intervalMs,
@@ -201,8 +215,24 @@ export function createObsidianClient(options: CreateObsidianClientOptions): Obsi
       return parseCommandIds(output);
     },
     exec(command: string, args: Record<string, ObsidianArg> = {}, execOptions: ExecOptions = {}) {
+      const { recoverable, ...request } = mergeExecOptions(defaultExecOptions, execOptions);
+
+      if ((recoverable ?? recoverableByDefault) && !NON_RECOVERABLE_COMMANDS.has(command)) {
+        return runRecoverableExec(
+          {
+            bin: this.bin,
+            state: dispatchState,
+            transport,
+            vault: options.vault,
+          },
+          command,
+          args,
+          request,
+        );
+      }
+
       return transport({
-        ...mergeExecOptions(defaultExecOptions, execOptions),
+        ...request,
         argv: buildCommandArgv(options.vault, command, args),
         bin: this.bin,
       });

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -41,6 +41,24 @@ import { sleep, waitForValue } from "./wait";
  */
 const NON_RECOVERABLE_COMMANDS = new Set(["dev:mobile", "plugins:restrict", "reload", "restart"]);
 
+/**
+ * The generic `command` verb reaches any palette command by id, including the
+ * built-ins that destroy the renderer context. Plugin commands with reload
+ * side effects cannot be enumerated here - route those through
+ * `recoverable: false` explicitly.
+ */
+const NON_RECOVERABLE_COMMAND_IDS = new Set(["app:reload", "app:quit"]);
+
+function isNonRecoverableCommand(command: string, args: Record<string, ObsidianArg>): boolean {
+  if (NON_RECOVERABLE_COMMANDS.has(command)) {
+    return true;
+  }
+
+  return (
+    command === "command" && typeof args.id === "string" && NON_RECOVERABLE_COMMAND_IDS.has(args.id)
+  );
+}
+
 export function createObsidianClient(options: CreateObsidianClientOptions): ObsidianClient {
   const transport = options.transport ?? executeCommand;
   // Recoverable dispatch only means anything against the real CLI: a custom
@@ -217,7 +235,7 @@ export function createObsidianClient(options: CreateObsidianClientOptions): Obsi
     exec(command: string, args: Record<string, ObsidianArg> = {}, execOptions: ExecOptions = {}) {
       const { recoverable, ...request } = mergeExecOptions(defaultExecOptions, execOptions);
 
-      if ((recoverable ?? recoverableByDefault) && !NON_RECOVERABLE_COMMANDS.has(command)) {
+      if ((recoverable ?? recoverableByDefault) && !isNonRecoverableCommand(command, args)) {
         return runRecoverableExec(
           {
             bin: this.bin,

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -48,13 +48,16 @@ export const DISPATCH_COMMAND = "__obsidian-e2e:dispatch";
 
 const DISPATCH_REGISTRY = "__obsidianE2EDispatch";
 /**
- * Ring bound for remembered dispatches. Entries are small strings; the cap
- * only exists so an eternal warm instance cannot grow without bound. Pending
- * entries are never evicted (evicting one would forget an in-flight dedup),
- * and a done entry is only reclaimed after 2000 younger dispatches - far
- * beyond what any client still polling for it could observe.
+ * Grace added to a dispatch's remaining deadline to form its registry entry's
+ * TTL. Eviction is TTL-based, not slot-based, so the at-most-once argument
+ * holds at any traffic volume: an entry provably outlives every moment its
+ * caller could still resend (resends stop at the deadline; the entry survives
+ * to deadline + margin), and memory stays bounded by traffic rate x TTL
+ * because expired entries are reclaimed as new dispatches arrive.
  */
-const DISPATCH_REGISTRY_CAP = 2_000;
+const DISPATCH_ENTRY_TTL_MARGIN_MS = 60_000;
+/** Oldest entries scanned for expiry per insert; keeps eviction amortized O(1). */
+const DISPATCH_EVICTION_SCAN_LIMIT = 50;
 
 /**
  * Process budget for a single dispatch attempt. Commands normally settle in
@@ -125,10 +128,7 @@ interface DispatchPollResult {
  * re-wrapping. `installId: null` reports an app without `window.handleCli`,
  * which the client treats as "recovery unsupported, use the direct path".
  */
-export function buildDispatchShimCode(
-  installId: string,
-  registryCap: number = DISPATCH_REGISTRY_CAP,
-): string {
+export function buildDispatchShimCode(installId: string): string {
   return [
     "(()=>{",
     `const existing=globalThis.${DISPATCH_REGISTRY};`,
@@ -137,7 +137,10 @@ export function buildDispatchShimCode(
     "if(typeof handleCli!=='function'){return {installId:null};}",
     `const installId=${JSON.stringify(installId)};`,
     "const ops=new Map();",
-    `const evictDone=()=>{if(ops.size<=${registryCap}){return;}for(const [nonce,entry] of ops){if(entry.state==='done'){ops.delete(nonce);return;}}};`,
+    // TTL-based eviction: an entry is reclaimable only after the deadline its
+    // own payload declared (plus margin) has passed, i.e. only once no caller
+    // can still resend its nonce. Pending entries are never evicted.
+    `const evictExpired=()=>{const now=Date.now();let scanned=0;for(const [nonce,entry] of ops){if(++scanned>${DISPATCH_EVICTION_SCAN_LIMIT}){return;}if(entry.state==='done'&&entry.expiresAt<now){ops.delete(nonce);}}};`,
     "window.handleCli=(argv)=>{",
     `if(!Array.isArray(argv)||argv.length!==2||argv[0]!==${JSON.stringify(DISPATCH_COMMAND)}||typeof argv[1]!=='string'||!argv[1].startsWith(${JSON.stringify(PAYLOAD_PREFIX)})){return handleCli(argv);}`,
     "let payload;",
@@ -150,14 +153,15 @@ export function buildDispatchShimCode(
     "const nonce=String(payload.nonce);",
     "let entry=ops.get(nonce);",
     "if(!entry){",
-    "entry={state:'pending',reply:null,settled:null};",
+    "const ttlMs=typeof payload.ttlMs==='number'?payload.ttlMs:120000;",
+    "entry={state:'pending',reply:null,settled:null,expiresAt:Date.now()+ttlMs};",
     // Reply formatting mirrors Obsidian's main process exactly (a falsy
     // resolution writes nothing - `d && b(d)`; string throw -> "Error: " + s;
     // other throw -> String(err)), so the recovered output is byte-identical
     // to the direct CLI output.
     "entry.settled=Promise.resolve().then(()=>handleCli(payload.argv)).then((value)=>value?String(value):'',(error)=>typeof error==='string'?'Error: '+error:String(error)).then((reply)=>{entry.state='done';entry.reply=reply;return reply;});",
     "ops.set(nonce,entry);",
-    "evictDone();",
+    "evictExpired();",
     "}",
     "return entry.settled.then((reply)=>JSON.stringify({installId,state:'done',reply}));",
     "};",
@@ -185,11 +189,13 @@ export function buildDispatchPayload(
   nonce: string,
   command: string,
   args: Record<string, ObsidianArg>,
+  ttlMs: number,
 ): string {
   return JSON.stringify({
     argv: [command, ...buildArgTokens(args)],
     installId,
     nonce,
+    ttlMs,
   });
 }
 
@@ -229,11 +235,31 @@ export function parseDispatchEnvelope(stdout: string): DispatchEnvelope | null {
   return null;
 }
 
+const INSTALL_DEADLINE = Symbol("install-deadline");
+
+async function raceAgainstDeadline<T>(
+  promise: Promise<T>,
+  deadlineMs: number,
+): Promise<T | typeof INSTALL_DEADLINE> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<typeof INSTALL_DEADLINE>((resolve) => {
+        timer = setTimeout(() => resolve(INSTALL_DEADLINE), Math.max(0, deadlineMs));
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 /**
  * Reconstruct the ExecResult the direct CLI path would have produced from a
  * stored reply. The CLI client exits 0 whenever the server serves a reply -
- * including "Error: ..." replies - and appends a newline to non-empty output;
- * an empty reply writes nothing (verified live against Obsidian 1.13.4).
+ * including "Error: ..." replies - and appends a newline to non-empty output
+ * when the reply lacks one; an empty reply writes nothing (verified live
+ * against Obsidian 1.13.4 and its decompiled main process).
  */
 function synthesizeExecResult(bin: string, argv: string[], reply: string): ExecResult {
   return {
@@ -316,14 +342,14 @@ export async function runRecoverableExec(
         );
       }
 
+      // The install promise is shared across callers, so a caller with a
+      // short deadline must not inherit another caller's install budget: race
+      // it against this call's own remaining time. Timing out the race leaves
+      // the shared install untouched for other callers and is provably safe
+      // for this one - nothing was dispatched for its nonce.
+      let raced: string | typeof INSTALL_DEADLINE | null;
       try {
-        const installId = await state.installPromise;
-        if (installId === null) {
-          state.unsupported = true;
-          return null;
-        }
-        state.installId = installId;
-        return installId;
+        raced = await raceAgainstDeadline(state.installPromise, remaining());
       } catch (error) {
         state.installPromise = null;
         // Only a lost install reply is worth retrying. Hard failures (connect
@@ -342,7 +368,24 @@ export async function runRecoverableExec(
           );
         }
         await sleep(Math.min(DISPATCH_POLL_INTERVAL_MS, remaining()));
+        continue;
       }
+
+      if (raced === INSTALL_DEADLINE) {
+        throw fail(
+          "undelivered",
+          `The dispatch shim install did not complete within this call's ${timeoutMs}ms deadline; the command was never dispatched and did not run`,
+          lastError,
+        );
+      }
+
+      if (raced === null) {
+        state.unsupported = true;
+        return null;
+      }
+
+      state.installId = raced;
+      return raced;
     }
   };
 
@@ -366,8 +409,13 @@ export async function runRecoverableExec(
     });
   }
 
+  // The entry TTL outlives every moment this call could still resend (resends
+  // stop at the deadline; the entry survives to deadline + margin), which is
+  // what makes "missing in the pinned generation" proof of non-execution.
+  const entryTtl = () => remaining() + DISPATCH_ENTRY_TTL_MARGIN_MS;
+
   let installId = initialInstallId;
-  let payload = buildDispatchPayload(installId, nonce, command, args);
+  let payload = buildDispatchPayload(installId, nonce, command, args, entryTtl());
   let confirmedRunning = false;
   let shouldSend = true;
   // Attempts whose fate is unknown (timed out). While any exist, entering a
@@ -439,7 +487,7 @@ export async function runRecoverableExec(
             );
           }
           installId = reinstalledId;
-          payload = buildDispatchPayload(installId, nonce, command, args);
+          payload = buildDispatchPayload(installId, nonce, command, args, entryTtl());
           shouldSend = true;
           await sleep(Math.max(0, Math.min(DISPATCH_POLL_INTERVAL_MS, remaining())));
           continue;

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -185,10 +185,17 @@ export function buildDispatchPayload(
 }
 
 /**
- * Parse a dispatch attempt's stdout. `null` means the reply did not come from
- * the shim - Obsidian's real parser answered (`Error: Command ... not found`),
- * i.e. the shim is gone and the inner command provably did not run.
+ * Whether a served non-envelope reply is Obsidian's own "command not found"
+ * answer for the dispatch verb - the one reply that proves the shim is gone
+ * AND the inner command was never parsed, making a resend safe. Any other
+ * non-envelope reply (e.g. a frame-disposal error delivered by the main
+ * process) leaves the dispatch's fate unknown.
  */
+export function isDispatchVerbNotFound(stdout: string): boolean {
+  return stdout.includes(`"${DISPATCH_COMMAND}" not found`);
+}
+
+/** Parse a dispatch attempt's stdout; `null` means it is not a shim envelope. */
 export function parseDispatchEnvelope(stdout: string): DispatchEnvelope | null {
   let parsed: unknown;
 
@@ -374,11 +381,23 @@ export async function runRecoverableExec(
         });
         const envelope = parseDispatchEnvelope(attempt.stdout);
 
-        if (envelope === null || envelope.state === "stale") {
-          // The shim is gone (Obsidian's parser answered "not found") or it
-          // was reinstalled under a new generation (stale refusal). Either
-          // way THIS attempt provably did not run. Re-pinning and resending
-          // is safe only while no earlier attempt has unknown fate.
+        if (envelope === null && !isDispatchVerbNotFound(attempt.stdout)) {
+          // A served reply that is neither a shim envelope nor Obsidian's
+          // not-found answer for the dispatch verb. The known producer is a
+          // renderer teardown mid-request (Obsidian's main process converts
+          // the executeJavaScript rejection into a delivered string like
+          // "Error: Render frame was disposed..."), in which case the
+          // dispatch may have executed before the context died - resending
+          // would risk a double run. Treat the fate as unknown and let the
+          // polls classify the context.
+          unknownFateAttempts += 1;
+          lastError = new Error(`Unrecognized dispatch reply: ${attempt.stdout.slice(0, 500)}`);
+        } else if (envelope === null || envelope.state === "stale") {
+          // Obsidian's parser answered "command not found" (the shim is gone
+          // and the inner command was never parsed) or the live shim refused
+          // a payload pinned to a previous generation. Either way THIS
+          // attempt provably did not run. Re-pinning and resending is safe
+          // only while no earlier attempt has unknown fate.
           if (unknownFateAttempts > 0) {
             throw contextReset(installId);
           }
@@ -397,7 +416,9 @@ export async function runRecoverableExec(
           continue;
         }
 
-        return synthesizeExecResult(ctx.bin, directArgv, envelope.reply);
+        if (envelope !== null && envelope.state === "done") {
+          return synthesizeExecResult(ctx.bin, directArgv, envelope.reply);
+        }
       } catch (error) {
         if (error instanceof ObsidianCommandDispatchError) {
           throw error;

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -68,6 +68,14 @@ const DISPATCH_INTERNAL_TIMEOUT_MS = 10_000;
 const DISPATCH_POLL_INTERVAL_MS = 100;
 /** Mirrors the transport's default command timeout, which bounded the direct form. */
 const DEFAULT_DISPATCH_TIMEOUT_MS = 30_000;
+/**
+ * Hard bound on how many times one exec() call may send its dispatch. Resends
+ * are only ever authorized by proof the nonce never ran, so a pathological
+ * environment (e.g. an app stuck in a reload loop answering "not found"
+ * forever) fails with a precise `undelivered` instead of hammering the CLI
+ * socket until the deadline.
+ */
+const MAX_DISPATCH_SENDS = 8;
 
 const PAYLOAD_PREFIX = "payload=";
 
@@ -143,10 +151,11 @@ export function buildDispatchShimCode(
     "let entry=ops.get(nonce);",
     "if(!entry){",
     "entry={state:'pending',reply:null,settled:null};",
-    // Reply formatting mirrors Obsidian's main process exactly (resolve ->
-    // value; string throw -> "Error: " + s; other throw -> String(err)), so
-    // the recovered output is byte-identical to the direct CLI output.
-    "entry.settled=Promise.resolve().then(()=>handleCli(payload.argv)).then((value)=>value==null?'':String(value),(error)=>typeof error==='string'?'Error: '+error:String(error)).then((reply)=>{entry.state='done';entry.reply=reply;return reply;});",
+    // Reply formatting mirrors Obsidian's main process exactly (a falsy
+    // resolution writes nothing - `d && b(d)`; string throw -> "Error: " + s;
+    // other throw -> String(err)), so the recovered output is byte-identical
+    // to the direct CLI output.
+    "entry.settled=Promise.resolve().then(()=>handleCli(payload.argv)).then((value)=>value?String(value):'',(error)=>typeof error==='string'?'Error: '+error:String(error)).then((reply)=>{entry.state='done';entry.reply=reply;return reply;});",
     "ops.set(nonce,entry);",
     "evictDone();",
     "}",
@@ -317,6 +326,13 @@ export async function runRecoverableExec(
         return installId;
       } catch (error) {
         state.installPromise = null;
+        // Only a lost install reply is worth retrying. Hard failures (connect
+        // refused on a cold app, nonzero exits, garbage replies) are the same
+        // persistent conditions the direct path surfaces immediately, and
+        // callers like waitFor probes rely on that fast failure.
+        if (!(error instanceof ObsidianCommandTimeoutError)) {
+          throw error;
+        }
         lastError = error;
         if (remaining() <= DISPATCH_POLL_INTERVAL_MS) {
           throw fail(
@@ -368,9 +384,21 @@ export async function runRecoverableExec(
     );
   };
 
+  let sends = 0;
+
   while (remaining() > 0) {
     if (shouldSend) {
       shouldSend = false;
+      if (sends >= MAX_DISPATCH_SENDS) {
+        // Every resend was authorized by proof the nonce never ran, so at the
+        // cap the command still provably has not executed.
+        throw fail(
+          "undelivered",
+          `The dispatch was sent ${sends} times and each send provably never ran (the environment keeps rejecting or losing it before dispatch); the command did not execute`,
+          lastError,
+        );
+      }
+      sends += 1;
       try {
         const attempt = await ctx.transport({
           ...execOptions,
@@ -413,12 +441,14 @@ export async function runRecoverableExec(
           installId = reinstalledId;
           payload = buildDispatchPayload(installId, nonce, command, args);
           shouldSend = true;
+          await sleep(Math.max(0, Math.min(DISPATCH_POLL_INTERVAL_MS, remaining())));
           continue;
         }
 
         if (envelope !== null && envelope.state === "done") {
           return synthesizeExecResult(ctx.bin, directArgv, envelope.reply);
         }
+        // Unknown fate falls through to the poll phase.
       } catch (error) {
         if (error instanceof ObsidianCommandDispatchError) {
           throw error;
@@ -428,9 +458,15 @@ export async function runRecoverableExec(
           lastError = error;
         } else if (error instanceof ObsidianCommandError && execOptions.allowNonZeroExit) {
           // A nonzero exit means the socket failed before a reply was served;
-          // callers that opted into nonzero exits get the result, as on the
-          // direct path.
-          return error.result;
+          // callers that opted into nonzero exits get the outcome, reported
+          // against their own command rather than the dispatch internals.
+          return {
+            argv: directArgv,
+            command: ctx.bin,
+            exitCode: error.result.exitCode,
+            stderr: error.result.stderr,
+            stdout: error.result.stdout,
+          };
         } else {
           throw error;
         }
@@ -459,8 +495,9 @@ export async function runRecoverableExec(
       } else if (poll.state === "missing" && !confirmedRunning) {
         // Same generation and no registry entry: the attempt provably never
         // dispatched (a delayed duplicate that fires later is dedup'd by the
-        // nonce). Resend immediately.
+        // nonce). Resend.
         shouldSend = true;
+        await sleep(Math.max(0, Math.min(DISPATCH_POLL_INTERVAL_MS, remaining())));
         continue;
       }
     } catch (error) {
@@ -483,7 +520,7 @@ export async function runRecoverableExec(
 
   throw fail(
     "ambiguous-delivery",
-    `No dispatch attempt was acknowledged within ${timeoutMs}ms and no in-app record of the command appeared; it may or may not have started. The nonce was never re-dispatched, so the command cannot have run twice`,
+    `No dispatch attempt was acknowledged within ${timeoutMs}ms and no in-app record of the command appeared; it may or may not have started. Resends only happen when the registry proves the nonce never ran, so the command cannot have run twice`,
     lastError,
   );
 }

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -1,0 +1,468 @@
+import { randomUUID } from "node:crypto";
+
+import { buildArgTokens, buildCommandArgv } from "./args";
+import {
+  ObsidianCommandDispatchError,
+  ObsidianCommandError,
+  ObsidianCommandTimeoutError,
+  isRecord,
+} from "./errors";
+import { runEvalJson } from "../dev/eval-json";
+import type { CommandTransport, ExecOptions, ExecResult, ObsidianArg } from "./types";
+import { sleep } from "./wait";
+
+/**
+ * Recoverable command dispatch for `exec()` (#25).
+ *
+ * Every Obsidian CLI command travels client process -> unix socket -> app main
+ * process -> `webContents.executeJavaScript("window.handleCli(argv)")` in the
+ * renderer -> the resolved string crosses back over the same bridge -> socket
+ * write. The bridge loses and delays messages in both directions under load
+ * (observed live: a `plugin:reload` completed in-app in 11ms and its reply
+ * never arrived; an eval request was delayed 13.7s while neighbors were
+ * instant), and Obsidian's CLI server has no timeout or retry around it - a
+ * lost reply hangs the client until our transport kills it.
+ *
+ * The protocol here keeps the happy path at a single CLI roundtrip while
+ * making a lost reply recoverable and a lost request safely resendable:
+ *
+ * - A one-time shim wraps `window.handleCli` in the renderer. It passes every
+ *   normal command through untouched and intercepts one synthetic verb,
+ *   `__obsidian-e2e:dispatch payload=<json>`, whose payload carries the real
+ *   command argv, a per-call nonce, and the shim generation (`installId`) the
+ *   client verified.
+ * - The shim records `{state:'pending'}` under the nonce before dispatching,
+ *   stores the final reply on settle, and dedups: a second arrival of the same
+ *   nonce joins the original run instead of re-dispatching. Payloads pinned to
+ *   another generation are refused (`state:'stale'`) without dispatching.
+ * - The client sends one dispatch attempt on a short process budget; if the
+ *   reply is lost it polls the registry with idempotent reads, and resends the
+ *   same nonce only when the registry proves the command never dispatched in
+ *   the pinned generation.
+ *
+ * Together nonce dedup + generation pinning give at-most-once execution
+ * unconditionally, and exactly-once whenever the renderer context survives -
+ * the only case in which the command could have run at all.
+ */
+export const DISPATCH_COMMAND = "__obsidian-e2e:dispatch";
+
+const DISPATCH_REGISTRY = "__obsidianE2EDispatch";
+/**
+ * Ring bound for remembered dispatches. Entries are small strings; the cap
+ * only exists so an eternal warm instance cannot grow without bound. Pending
+ * entries are never evicted (evicting one would forget an in-flight dedup),
+ * and a done entry is only reclaimed after 2000 younger dispatches - far
+ * beyond what any client still polling for it could observe.
+ */
+const DISPATCH_REGISTRY_CAP = 2_000;
+
+/**
+ * Process budget for a single dispatch attempt. Commands normally settle in
+ * milliseconds; when a reply is lost this bounds the stall before recovery
+ * polling starts. A command still running when the budget kills the CLI
+ * process is unaffected in-app - polls carry its result afterwards.
+ */
+const DISPATCH_ATTEMPT_TIMEOUT_MS = 5_000;
+/** Budget for internal install/poll commands; mirrors the evalJsonAsync value. */
+const DISPATCH_INTERNAL_TIMEOUT_MS = 10_000;
+const DISPATCH_POLL_INTERVAL_MS = 100;
+/** Mirrors the transport's default command timeout, which bounded the direct form. */
+const DEFAULT_DISPATCH_TIMEOUT_MS = 30_000;
+
+const PAYLOAD_PREFIX = "payload=";
+
+export interface DispatchState {
+  installId: string | null;
+  installPromise: Promise<string | null> | null;
+  unsupported: boolean;
+}
+
+export function createDispatchState(): DispatchState {
+  return {
+    installId: null,
+    installPromise: null,
+    unsupported: false,
+  };
+}
+
+export interface DispatchContext {
+  bin: string;
+  state: DispatchState;
+  transport: CommandTransport;
+  vault: string;
+}
+
+interface DispatchDoneEnvelope {
+  installId: string;
+  reply: string;
+  state: "done";
+}
+
+interface DispatchStaleEnvelope {
+  installId: string;
+  state: "stale";
+}
+
+type DispatchEnvelope = DispatchDoneEnvelope | DispatchStaleEnvelope;
+
+interface DispatchPollResult {
+  installId: string;
+  reply: string | null;
+  state: "done" | "missing" | "pending";
+}
+
+/**
+ * Installer for the in-app dispatch shim. Idempotent: a repeated install (e.g.
+ * after its own reply was lost) returns the existing generation instead of
+ * re-wrapping. `installId: null` reports an app without `window.handleCli`,
+ * which the client treats as "recovery unsupported, use the direct path".
+ */
+export function buildDispatchShimCode(
+  installId: string,
+  registryCap: number = DISPATCH_REGISTRY_CAP,
+): string {
+  return [
+    "(()=>{",
+    `const existing=globalThis.${DISPATCH_REGISTRY};`,
+    "if(existing){return {installId:existing.installId};}",
+    "const handleCli=window.handleCli;",
+    "if(typeof handleCli!=='function'){return {installId:null};}",
+    `const installId=${JSON.stringify(installId)};`,
+    "const ops=new Map();",
+    `const evictDone=()=>{if(ops.size<=${registryCap}){return;}for(const [nonce,entry] of ops){if(entry.state==='done'){ops.delete(nonce);return;}}};`,
+    "window.handleCli=(argv)=>{",
+    `if(!Array.isArray(argv)||argv.length!==2||argv[0]!==${JSON.stringify(DISPATCH_COMMAND)}||typeof argv[1]!=='string'||!argv[1].startsWith(${JSON.stringify(PAYLOAD_PREFIX)})){return handleCli(argv);}`,
+    "let payload;",
+    `try{payload=JSON.parse(argv[1].slice(${PAYLOAD_PREFIX.length}));}catch(error){return Promise.resolve(JSON.stringify({installId,state:'done',reply:'Error: obsidian-e2e dispatch payload was not valid JSON'}));}`,
+    // Generation pinning: a payload pinned to a previous install (the window
+    // reloaded between pinning and arrival) is refused without dispatching, so
+    // a delayed duplicate can never execute against a registry that lost its
+    // dedup memory.
+    "if(payload.installId!==installId){return Promise.resolve(JSON.stringify({installId,state:'stale'}));}",
+    "const nonce=String(payload.nonce);",
+    "let entry=ops.get(nonce);",
+    "if(!entry){",
+    "entry={state:'pending',reply:null,settled:null};",
+    // Reply formatting mirrors Obsidian's main process exactly (resolve ->
+    // value; string throw -> "Error: " + s; other throw -> String(err)), so
+    // the recovered output is byte-identical to the direct CLI output.
+    "entry.settled=Promise.resolve().then(()=>handleCli(payload.argv)).then((value)=>value==null?'':String(value),(error)=>typeof error==='string'?'Error: '+error:String(error)).then((reply)=>{entry.state='done';entry.reply=reply;return reply;});",
+    "ops.set(nonce,entry);",
+    "evictDone();",
+    "}",
+    "return entry.settled.then((reply)=>JSON.stringify({installId,state:'done',reply}));",
+    "};",
+    `globalThis.${DISPATCH_REGISTRY}={installId,ops};`,
+    "return {installId};",
+    "})()",
+  ].join("");
+}
+
+/** Pure read; safe to repeat after any lost or failed reply. */
+export function buildDispatchPollCode(nonce: string): string {
+  return [
+    "(()=>{",
+    `const shim=globalThis.${DISPATCH_REGISTRY};`,
+    "if(!shim){return null;}",
+    `const entry=shim.ops.get(${JSON.stringify(nonce)})??null;`,
+    "if(!entry){return {installId:shim.installId,state:'missing',reply:null};}",
+    "return {installId:shim.installId,state:entry.state,reply:entry.state==='done'?entry.reply:null};",
+    "})()",
+  ].join("");
+}
+
+export function buildDispatchPayload(
+  installId: string,
+  nonce: string,
+  command: string,
+  args: Record<string, ObsidianArg>,
+): string {
+  return JSON.stringify({
+    argv: [command, ...buildArgTokens(args)],
+    installId,
+    nonce,
+  });
+}
+
+/**
+ * Parse a dispatch attempt's stdout. `null` means the reply did not come from
+ * the shim - Obsidian's real parser answered (`Error: Command ... not found`),
+ * i.e. the shim is gone and the inner command provably did not run.
+ */
+export function parseDispatchEnvelope(stdout: string): DispatchEnvelope | null {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(stdout.trim());
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(parsed) || typeof parsed.installId !== "string") {
+    return null;
+  }
+
+  if (parsed.state === "stale") {
+    return { installId: parsed.installId, state: "stale" };
+  }
+
+  if (parsed.state === "done" && typeof parsed.reply === "string") {
+    return { installId: parsed.installId, reply: parsed.reply, state: "done" };
+  }
+
+  return null;
+}
+
+/**
+ * Reconstruct the ExecResult the direct CLI path would have produced from a
+ * stored reply. The CLI client exits 0 whenever the server serves a reply -
+ * including "Error: ..." replies - and appends a newline to non-empty output;
+ * an empty reply writes nothing (verified live against Obsidian 1.13.4).
+ */
+function synthesizeExecResult(bin: string, argv: string[], reply: string): ExecResult {
+  return {
+    argv,
+    command: bin,
+    exitCode: 0,
+    stderr: "",
+    stdout: reply === "" ? "" : reply.endsWith("\n") ? reply : `${reply}\n`,
+  };
+}
+
+export async function runRecoverableExec(
+  ctx: DispatchContext,
+  command: string,
+  args: Record<string, ObsidianArg>,
+  execOptions: ExecOptions,
+): Promise<ExecResult> {
+  const timeoutMs = execOptions.timeoutMs ?? DEFAULT_DISPATCH_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+  const directArgv = buildCommandArgv(ctx.vault, command, args);
+  const remaining = () => deadline - Date.now();
+  const budget = (ms: number) => Math.max(1, Math.min(ms, remaining()));
+
+  const internalOptions = (budgetMs: number): ExecOptions => ({
+    ...execOptions,
+    allowNonZeroExit: false,
+    timeoutMs: budget(budgetMs),
+  });
+
+  // Direct evals used by install and polls. They bypass exec() on purpose:
+  // routing them through the recoverable path would recurse.
+  const directDev = {
+    evalRaw: async (code: string, evalOptions: ExecOptions = {}) => {
+      const result = await ctx.transport({
+        ...evalOptions,
+        argv: buildCommandArgv(ctx.vault, "eval", { code }),
+        bin: ctx.bin,
+      });
+      return result.stdout.trimEnd();
+    },
+  };
+
+  const nonce = randomUUID();
+  const fail = (
+    reason: "ambiguous-delivery" | "context-reset" | "still-pending" | "undelivered",
+    message: string,
+    causeError?: unknown,
+  ) =>
+    new ObsidianCommandDispatchError(
+      `${message} (command "${command}", nonce ${nonce})`,
+      reason,
+      nonce,
+      directArgv,
+      causeError,
+    );
+
+  let lastError: unknown;
+
+  // Install phase. The memoized promise is shared across concurrent exec()
+  // calls; a failed install clears it so the next caller retries. Detection of
+  // an app without window.handleCli is cached and downgrades every future
+  // exec() to the direct path.
+  const ensureShim = async (): Promise<string | null> => {
+    const { state } = ctx;
+    while (true) {
+      if (state.unsupported) {
+        return null;
+      }
+
+      if (!state.installPromise) {
+        const candidate = randomUUID();
+        state.installPromise = runEvalJson<{ installId: string | null } | null>(
+          directDev,
+          buildDispatchShimCode(candidate),
+          internalOptions(DISPATCH_INTERNAL_TIMEOUT_MS),
+        ).then((value) =>
+          // Anything but the shim's own {installId: string} answer means the
+          // app cannot host the protocol; degrade to the direct path.
+          typeof value?.installId === "string" ? value.installId : null,
+        );
+      }
+
+      try {
+        const installId = await state.installPromise;
+        if (installId === null) {
+          state.unsupported = true;
+          return null;
+        }
+        state.installId = installId;
+        return installId;
+      } catch (error) {
+        state.installPromise = null;
+        lastError = error;
+        if (remaining() <= DISPATCH_POLL_INTERVAL_MS) {
+          throw fail(
+            "undelivered",
+            `The dispatch shim could not be installed within ${timeoutMs}ms; the command was never dispatched and did not run`,
+            lastError,
+          );
+        }
+        await sleep(Math.min(DISPATCH_POLL_INTERVAL_MS, remaining()));
+      }
+    }
+  };
+
+  const invalidateShim = (installId: string) => {
+    if (ctx.state.installId === installId) {
+      ctx.state.installId = null;
+      ctx.state.installPromise = null;
+    }
+  };
+
+  const initialInstallId = await ensureShim();
+
+  if (initialInstallId === null) {
+    // App without window.handleCli: recovery is unsupported, preserve the
+    // exact legacy single-shot behavior.
+    return ctx.transport({
+      ...execOptions,
+      argv: directArgv,
+      bin: ctx.bin,
+      timeoutMs: budget(timeoutMs),
+    });
+  }
+
+  let installId = initialInstallId;
+  let payload = buildDispatchPayload(installId, nonce, command, args);
+  let confirmedRunning = false;
+  let shouldSend = true;
+  // Attempts whose fate is unknown (timed out). While any exist, entering a
+  // new shim generation is not provably safe: the attempt may have executed
+  // just before the context reset that created the generation.
+  let unknownFateAttempts = 0;
+
+  const contextReset = (installIdAtFailure: string, causeError?: unknown) => {
+    invalidateShim(installIdAtFailure);
+    return fail(
+      "context-reset",
+      "The Obsidian renderer context was reset (e.g. an app or vault reload) while the command was in flight; whether it executed before the reset is unknowable",
+      causeError,
+    );
+  };
+
+  while (remaining() > 0) {
+    if (shouldSend) {
+      shouldSend = false;
+      try {
+        const attempt = await ctx.transport({
+          ...execOptions,
+          allowNonZeroExit: false,
+          argv: buildCommandArgv(ctx.vault, DISPATCH_COMMAND, { payload }),
+          bin: ctx.bin,
+          timeoutMs: budget(DISPATCH_ATTEMPT_TIMEOUT_MS),
+        });
+        const envelope = parseDispatchEnvelope(attempt.stdout);
+
+        if (envelope === null || envelope.state === "stale") {
+          // The shim is gone (Obsidian's parser answered "not found") or it
+          // was reinstalled under a new generation (stale refusal). Either
+          // way THIS attempt provably did not run. Re-pinning and resending
+          // is safe only while no earlier attempt has unknown fate.
+          if (unknownFateAttempts > 0) {
+            throw contextReset(installId);
+          }
+          invalidateShim(installId);
+          const reinstalledId = await ensureShim();
+          if (reinstalledId === null) {
+            throw fail(
+              "undelivered",
+              "The dispatch shim disappeared and could not be reinstalled; the command was never dispatched and did not run",
+              lastError,
+            );
+          }
+          installId = reinstalledId;
+          payload = buildDispatchPayload(installId, nonce, command, args);
+          shouldSend = true;
+          continue;
+        }
+
+        return synthesizeExecResult(ctx.bin, directArgv, envelope.reply);
+      } catch (error) {
+        if (error instanceof ObsidianCommandDispatchError) {
+          throw error;
+        }
+        if (error instanceof ObsidianCommandTimeoutError) {
+          unknownFateAttempts += 1;
+          lastError = error;
+        } else if (error instanceof ObsidianCommandError && execOptions.allowNonZeroExit) {
+          // A nonzero exit means the socket failed before a reply was served;
+          // callers that opted into nonzero exits get the result, as on the
+          // direct path.
+          return error.result;
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    try {
+      const poll = await runEvalJson<DispatchPollResult | null>(
+        directDev,
+        buildDispatchPollCode(nonce),
+        internalOptions(DISPATCH_INTERNAL_TIMEOUT_MS),
+      );
+
+      if (poll === null || poll.installId !== installId) {
+        // Polls only run after a timed-out attempt, whose fate is unknown; a
+        // wiped or regenerated registry makes that fate unknowable.
+        throw contextReset(installId);
+      }
+
+      if (poll.state === "done" && poll.reply !== null) {
+        return synthesizeExecResult(ctx.bin, directArgv, poll.reply);
+      }
+
+      if (poll.state === "pending") {
+        confirmedRunning = true;
+      } else if (poll.state === "missing" && !confirmedRunning) {
+        // Same generation and no registry entry: the attempt provably never
+        // dispatched (a delayed duplicate that fires later is dedup'd by the
+        // nonce). Resend immediately.
+        shouldSend = true;
+        continue;
+      }
+    } catch (error) {
+      if (error instanceof ObsidianCommandDispatchError) {
+        throw error;
+      }
+      lastError = error;
+    }
+
+    await sleep(Math.max(0, Math.min(DISPATCH_POLL_INTERVAL_MS, remaining())));
+  }
+
+  if (confirmedRunning) {
+    throw fail(
+      "still-pending",
+      `The command is still running in Obsidian after ${timeoutMs}ms; its handler has not settled. It may still complete in-app`,
+      lastError,
+    );
+  }
+
+  throw fail(
+    "ambiguous-delivery",
+    `No dispatch attempt was acknowledged within ${timeoutMs}ms and no in-app record of the command appeared; it may or may not have started. The nonce was never re-dispatched, so the command cannot have run twice`,
+    lastError,
+  );
+}

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -86,6 +86,52 @@ export class DevEvalAsyncError extends Error {
   }
 }
 
+/**
+ * Failure taxonomy for the recoverable `exec()` dispatch protocol. Extends the
+ * `evalJsonAsync` taxonomy with `undelivered` - unlike an eval kickoff, a
+ * dispatch that was never sent (the shim could not be installed) is *provably*
+ * unexecuted, and callers may safely retry:
+ *
+ * - `ambiguous-delivery`: no dispatch attempt was acknowledged and no in-app
+ *   record appeared before the deadline. The command may or may not have
+ *   started; the nonce was never re-dispatched, so it cannot have run twice.
+ * - `context-reset`: the renderer context was reset (e.g. an app or vault
+ *   reload) while an attempt with unknown fate was in flight; whether the
+ *   command executed before the reset is unknowable.
+ * - `still-pending`: the command is confirmed running in-app but its handler
+ *   has not settled within the deadline. It may still complete afterwards.
+ * - `undelivered`: the dispatch shim could not be installed (or disappeared
+ *   before any attempt was acknowledged); the command was never dispatched
+ *   and did not run.
+ */
+export type ObsidianCommandDispatchFailureReason =
+  | "ambiguous-delivery"
+  | "context-reset"
+  | "still-pending"
+  | "undelivered";
+
+export class ObsidianCommandDispatchError extends Error {
+  readonly argv: string[];
+  readonly causeError?: unknown;
+  readonly nonce: string;
+  readonly reason: ObsidianCommandDispatchFailureReason;
+
+  constructor(
+    message: string,
+    reason: ObsidianCommandDispatchFailureReason,
+    nonce: string,
+    argv: string[],
+    causeError?: unknown,
+  ) {
+    super(message);
+    this.name = "ObsidianCommandDispatchError";
+    this.reason = reason;
+    this.nonce = nonce;
+    this.argv = argv;
+    this.causeError = causeError;
+  }
+}
+
 export class WaitForTimeoutError extends Error {
   readonly causeError?: unknown;
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -78,9 +78,12 @@ export interface ExecOptions {
   /**
    * Whether `exec()` uses the recoverable dispatch protocol (lost CLI replies
    * are recovered by nonce-registry polls instead of hanging until
-   * `timeoutMs`). Defaults to true on the built-in transport and false on a
-   * custom one; context-destroying verbs (`reload`, `restart`,
-   * `plugins:restrict`, `dev:mobile`) always use the direct path.
+   * `timeoutMs`). Defaults to true on the built-in transport and false on ANY
+   * custom `transport` - including one that merely wraps the built-in
+   * transport for logging; pass `recoverable: true` to opt such a wrapper
+   * back in. Context-destroying verbs (`reload`, `restart`,
+   * `plugins:restrict`, `dev:mobile`, `command` with `app:reload`/`app:quit`)
+   * always use the direct path.
    */
   recoverable?: boolean;
   /**

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -75,6 +75,19 @@ export interface ExecOptions {
   allowNonZeroExit?: boolean;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
+  /**
+   * Whether `exec()` uses the recoverable dispatch protocol (lost CLI replies
+   * are recovered by nonce-registry polls instead of hanging until
+   * `timeoutMs`). Defaults to true on the built-in transport and false on a
+   * custom one; context-destroying verbs (`reload`, `restart`,
+   * `plugins:restrict`, `dev:mobile`) always use the direct path.
+   */
+  recoverable?: boolean;
+  /**
+   * On the direct path: the process budget for the spawned CLI command. On
+   * the recoverable path: the overall deadline for the command's result;
+   * internal dispatch/poll commands run on their own short budgets.
+   */
   timeoutMs?: number;
 }
 

--- a/src/dev/eval-json.ts
+++ b/src/dev/eval-json.ts
@@ -192,6 +192,16 @@ export async function runEvalJsonAsync<T>(
     allowNonZeroExit: false,
     timeoutMs: Math.max(1, Math.min(budgetMs, deadline - Date.now())),
   });
+  // Poll and cleanup reads are already this protocol's own recovery mechanism
+  // (idempotent, retried); stacking exec()'s recoverable dispatch under them
+  // would only double the machinery and churn its registry. The kickoff keeps
+  // the recoverable default: exec() resends it only when the registry proves
+  // it never ran, so the exactly-once guarantee is preserved - and a lost
+  // kickoff reply now recovers instead of counting as ambiguous.
+  const directCommandOptions = (budgetMs: number): ExecOptions => ({
+    ...commandOptions(budgetMs),
+    recoverable: false,
+  });
   const pause = async () => {
     await sleep(Math.max(0, Math.min(ASYNC_EVAL_POLL_INTERVAL_MS, deadline - Date.now())));
   };
@@ -227,7 +237,7 @@ export async function runEvalJsonAsync<T>(
       entry = await runEvalJson<AsyncEvalEntry | null>(
         dev,
         buildEvalJsonAsyncPollCode(nonce),
-        commandOptions(ASYNC_EVAL_COMMAND_TIMEOUT_MS),
+        directCommandOptions(ASYNC_EVAL_COMMAND_TIMEOUT_MS),
       );
     } catch (error) {
       lastError = error;
@@ -251,7 +261,7 @@ export async function runEvalJsonAsync<T>(
           await runEvalJson<boolean>(
             dev,
             buildEvalJsonAsyncCleanupCode(nonce),
-            commandOptions(ASYNC_EVAL_CLEANUP_TIMEOUT_MS),
+            directCommandOptions(ASYNC_EVAL_CLEANUP_TIMEOUT_MS),
           );
         } catch {
           // Best-effort: a leaked entry is one small object in the renderer.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,15 @@ export { createObsidianClient } from "./core/client";
 export {
   DevEvalAsyncError,
   DevEvalError,
+  ObsidianCommandDispatchError,
   ObsidianCommandError,
   ObsidianCommandTimeoutError,
   WaitForTimeoutError,
 } from "./core/errors";
-export type { DevEvalAsyncFailureReason } from "./core/errors";
+export type {
+  DevEvalAsyncFailureReason,
+  ObsidianCommandDispatchFailureReason,
+} from "./core/errors";
 export {
   captureFailureArtifacts,
   DEFAULT_FAILURE_ARTIFACTS_DIR,

--- a/tests/core/client.test.ts
+++ b/tests/core/client.test.ts
@@ -771,6 +771,9 @@ describe("createObsidianClient", () => {
           ...process.env,
           OBSIDIAN_E2E_TEST_LOG: logPath,
         },
+        // The fake binary serves canned eval replies, not the dispatch shim
+        // protocol; this test exercises the direct path's argv plumbing.
+        recoverable: false,
       },
       vault: "dev",
     });

--- a/tests/core/dispatch.test.ts
+++ b/tests/core/dispatch.test.ts
@@ -1,0 +1,460 @@
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+import { createObsidianClient } from "../../src/core/client";
+import {
+  DISPATCH_COMMAND,
+  buildDispatchShimCode,
+  parseDispatchEnvelope,
+} from "../../src/core/dispatch";
+import {
+  ObsidianCommandDispatchError,
+  ObsidianCommandError,
+  ObsidianCommandTimeoutError,
+} from "../../src/core/errors";
+import { createExecResult } from "../helpers/create-exec-result";
+import { sleep } from "../../src/core/wait";
+import type { CommandTransport, ExecuteRequest } from "../../src/core/types";
+
+const SHIM_GLOBAL = "__obsidianE2EDispatch";
+
+type MutableGlobal = Record<string, unknown>;
+
+afterEach(() => {
+  const globals = globalThis as MutableGlobal;
+  delete globals[SHIM_GLOBAL];
+  delete globals.handleCli;
+  delete globals.window;
+});
+
+type RequestBehavior = "delay-request" | "drop-reply" | "fail-exit" | "timeout" | undefined;
+
+type CommandHandler = (flags: Record<string, string>) => unknown;
+
+/**
+ * Emulates the whole in-app side of the protocol by actually executing the
+ * generated shim/install/poll code in this process: `window.handleCli` is a
+ * miniature Obsidian dispatcher over `handlers` (string throws and all), the
+ * transport serves `eval` commands by evaluating their code against the real
+ * `globalThis`, and every other command is relayed through the current
+ * `window.handleCli` exactly like Obsidian's main process does. Behaviors
+ * model the observed transport failures: `drop-reply` executes the command and
+ * then throws (delivered, reply lost); `delay-request` queues the execution
+ * for a later `flushDelayed()` and throws (request stuck in the bridge);
+ * `timeout`/`fail-exit` fail without executing.
+ */
+function createDispatchHarness(handlers: Record<string, CommandHandler>) {
+  const globals = globalThis as MutableGlobal;
+  globals.window = globalThis;
+  const realHandleCli = async (argv: string[]) => {
+    const [name = "", ...tokens] = argv;
+    const handler = handlers[name];
+
+    if (!handler) {
+      throw `Command "${name}" not found. It may require a plugin to be enabled.`;
+    }
+
+    const flags: Record<string, string> = {};
+    for (const token of tokens) {
+      const separator = token.indexOf("=");
+      if (separator === -1) {
+        flags[token] = "true";
+      } else {
+        flags[token.slice(0, separator)] = token.slice(separator + 1);
+      }
+    }
+
+    return handler(flags);
+  };
+  globals.handleCli = realHandleCli;
+
+  const delayed: Array<() => Promise<string>> = [];
+  const requests: string[][] = [];
+  let behaviorFor: (request: ExecuteRequest) => RequestBehavior = () => undefined;
+
+  const serveThroughHandleCli = async (command: string, tokens: string[]): Promise<string> => {
+    // Fall back to the unwrapped dispatcher when a test removed
+    // window.handleCli to emulate an app without shim support.
+    const handleCli = ((globals.window as MutableGlobal).handleCli ?? realHandleCli) as (
+      argv: string[],
+    ) => Promise<unknown>;
+    try {
+      const value = (await handleCli([command, ...tokens])) as string | null | undefined;
+      return value == null ? "" : String(value);
+    } catch (error) {
+      return typeof error === "string" ? `Error: ${error}` : String(error);
+    }
+  };
+
+  const transport: CommandTransport = async (request) => {
+    requests.push(request.argv);
+    const behavior = behaviorFor(request);
+    const [, command = "", ...tokens] = request.argv;
+
+    if (behavior === "timeout") {
+      throw new ObsidianCommandTimeoutError(request.bin, request.argv, request.timeoutMs ?? 0);
+    }
+
+    if (behavior === "fail-exit") {
+      throw new ObsidianCommandError(
+        `Obsidian command failed with exit code 1: ${request.bin}`,
+        createExecResult(request.bin, request.argv, ""),
+      );
+    }
+
+    if (command === "eval") {
+      const code = (tokens[0] ?? "").slice("code=".length);
+      const output = (await (0, eval)(code)) as string;
+      return createExecResult(request.bin, request.argv, output);
+    }
+
+    if (behavior === "delay-request") {
+      delayed.push(() => serveThroughHandleCli(command, tokens));
+      throw new ObsidianCommandTimeoutError(request.bin, request.argv, request.timeoutMs ?? 0);
+    }
+
+    const served = serveThroughHandleCli(command, tokens);
+
+    if (behavior === "drop-reply") {
+      // Delivered but the reply is lost: the command keeps running in-app
+      // while the CLI process dies, exactly like the real transport kill.
+      await Promise.race([served.catch(() => ""), sleep(5)]);
+      throw new ObsidianCommandTimeoutError(request.bin, request.argv, request.timeoutMs ?? 0);
+    }
+
+    const output = await served;
+
+    return createExecResult(request.bin, request.argv, output ? `${output}\n` : "");
+  };
+
+  return {
+    createClient: (recoverable = true) =>
+      createObsidianClient({
+        defaultExecOptions: { recoverable },
+        transport,
+        vault: "test",
+      }),
+    delayed,
+    flushDelayed: async () => {
+      const pending = delayed.splice(0);
+      return Promise.all(pending.map((fire) => fire()));
+    },
+    requests,
+    setBehavior: (next: (request: ExecuteRequest) => RequestBehavior) => {
+      behaviorFor = next;
+    },
+  };
+}
+
+function dispatchRequests(requests: string[][]): string[][] {
+  return requests.filter((argv) => argv[1] === DISPATCH_COMMAND);
+}
+
+function installRequests(requests: string[][]): string[][] {
+  return requests.filter(
+    (argv) => argv[1] === "eval" && (argv[2] ?? "").includes("window.handleCli"),
+  );
+}
+
+describe("runRecoverableExec via client.exec", () => {
+  it("dispatches through the shim and returns a CLI-faithful result", async () => {
+    const seen: Array<Record<string, string>> = [];
+    const harness = createDispatchHarness({
+      greet: (flags) => {
+        seen.push(flags);
+        return `hello ${flags.name}`;
+      },
+    });
+    const client = harness.createClient();
+
+    const result = await client.exec("greet", { name: "world" });
+
+    expect(result).toMatchObject({ exitCode: 0, stderr: "", stdout: "hello world\n" });
+    // The synthesized argv reports the command the caller asked for.
+    expect(result.argv).toEqual(["vault=test", "greet", "name=world"]);
+    // The handler saw its exact flags - no nonce pollution.
+    expect(seen).toEqual([{ name: "world" }]);
+    expect(dispatchRequests(harness.requests)).toHaveLength(1);
+    expect(installRequests(harness.requests)).toHaveLength(1);
+
+    await client.exec("greet", { name: "again" });
+    // The shim install is memoized across calls.
+    expect(installRequests(harness.requests)).toHaveLength(1);
+  });
+
+  it("preserves CLI error semantics: error replies on stdout with exit code 0", async () => {
+    const harness = createDispatchHarness({
+      "throws-error": () => {
+        throw new Error("kaboom");
+      },
+      "throws-string": () => {
+        throw "nope";
+      },
+      quiet: () => undefined,
+    });
+    const client = harness.createClient();
+
+    await expect(client.exec("throws-string")).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: "Error: nope\n",
+    });
+    await expect(client.exec("throws-error")).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: "Error: kaboom\n",
+    });
+    await expect(client.exec("quiet")).resolves.toMatchObject({ exitCode: 0, stdout: "" });
+    await expect(client.exec("no-such-command")).resolves.toMatchObject({
+      exitCode: 0,
+      stdout:
+        'Error: Command "no-such-command" not found. It may require a plugin to be enabled.\n',
+    });
+  });
+
+  it("recovers a reply lost after the command executed - exactly once", async () => {
+    let runs = 0;
+    const harness = createDispatchHarness({
+      "run-once": () => {
+        runs += 1;
+        return "ran";
+      },
+    });
+    harness.setBehavior((request) =>
+      request.argv[1] === DISPATCH_COMMAND && dispatchRequests(harness.requests).length === 1
+        ? "drop-reply"
+        : undefined,
+    );
+    const client = harness.createClient();
+
+    const result = await client.exec("run-once");
+
+    expect(result.stdout).toBe("ran\n");
+    expect(runs).toBe(1);
+    // One dispatch attempt (reply dropped) + recovery polls, no resend.
+    expect(dispatchRequests(harness.requests)).toHaveLength(1);
+  });
+
+  it("a delayed dispatch firing after recovery cannot double-execute", async () => {
+    let runs = 0;
+    const harness = createDispatchHarness({
+      "run-once": () => {
+        runs += 1;
+        return "ran";
+      },
+    });
+    // First dispatch request gets stuck in the bridge; the resend goes through.
+    harness.setBehavior((request) =>
+      request.argv[1] === DISPATCH_COMMAND && dispatchRequests(harness.requests).length === 1
+        ? "delay-request"
+        : undefined,
+    );
+    const client = harness.createClient();
+
+    const result = await client.exec("run-once");
+
+    expect(result.stdout).toBe("ran\n");
+    expect(runs).toBe(1);
+    expect(dispatchRequests(harness.requests)).toHaveLength(2);
+
+    // The stuck original fires afterwards: the nonce dedup joins the finished
+    // run instead of re-executing, and replies with the stored envelope.
+    const [lateReply] = await harness.flushDelayed();
+    expect(runs).toBe(1);
+    expect(parseDispatchEnvelope(lateReply ?? "")).toMatchObject({ reply: "ran", state: "done" });
+  });
+
+  it("throws context-reset when the registry vanishes while an attempt's fate is unknown", async () => {
+    const harness = createDispatchHarness({
+      mutate: () => "mutated",
+    });
+    harness.setBehavior((request) => {
+      if (request.argv[1] !== DISPATCH_COMMAND) {
+        return undefined;
+      }
+      // The attempt executes but its reply is lost; then the renderer
+      // "reloads": the shim global and the wrapped handleCli disappear.
+      queueMicrotask(() => {
+        const globals = globalThis as MutableGlobal;
+        delete globals[SHIM_GLOBAL];
+      });
+      return "drop-reply";
+    });
+    const client = harness.createClient();
+
+    const error = await client.exec("mutate", {}, { timeoutMs: 2_000 }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ObsidianCommandDispatchError);
+    expect((error as ObsidianCommandDispatchError).reason).toBe("context-reset");
+
+    // The next exec() reinstalls the shim and works again.
+    harness.setBehavior(() => undefined);
+    await expect(client.exec("mutate")).resolves.toMatchObject({ stdout: "mutated\n" });
+    expect(installRequests(harness.requests)).toHaveLength(2);
+  });
+
+  it("reports still-pending when the handler never settles", async () => {
+    const harness = createDispatchHarness({
+      forever: () => new Promise(() => {}),
+    });
+    harness.setBehavior((request) =>
+      request.argv[1] === DISPATCH_COMMAND ? "drop-reply" : undefined,
+    );
+    const client = harness.createClient();
+
+    const error = await client.exec("forever", {}, { timeoutMs: 500 }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ObsidianCommandDispatchError);
+    expect((error as ObsidianCommandDispatchError).reason).toBe("still-pending");
+  });
+
+  it("reports ambiguous-delivery when nothing is ever acknowledged", async () => {
+    const harness = createDispatchHarness({});
+    harness.setBehavior((request) => {
+      if (request.argv[1] === DISPATCH_COMMAND) {
+        return "delay-request";
+      }
+      // Polls fail too, but only after the shim install succeeded.
+      if (request.argv[1] === "eval" && installRequests(harness.requests).length >= 1) {
+        return (request.argv[2] ?? "").includes("window.handleCli") ? undefined : "timeout";
+      }
+      return undefined;
+    });
+    const client = harness.createClient();
+
+    const error = await client.exec("anything", {}, { timeoutMs: 500 }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ObsidianCommandDispatchError);
+    expect((error as ObsidianCommandDispatchError).reason).toBe("ambiguous-delivery");
+    expect((error as ObsidianCommandDispatchError).causeError).toBeInstanceOf(
+      ObsidianCommandTimeoutError,
+    );
+  });
+
+  it("returns the socket failure result when the caller allows nonzero exits", async () => {
+    const harness = createDispatchHarness({});
+    harness.setBehavior((request) =>
+      request.argv[1] === DISPATCH_COMMAND ? "fail-exit" : undefined,
+    );
+    const client = harness.createClient();
+
+    await expect(client.exec("anything", {}, { allowNonZeroExit: true })).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: "",
+    });
+    await expect(client.exec("anything")).rejects.toBeInstanceOf(ObsidianCommandError);
+  });
+
+  it("keeps context-destroying verbs and recoverable:false on the direct path", async () => {
+    const harness = createDispatchHarness({
+      greet: () => "hello",
+      reload: () => "Reloading...",
+    });
+    const client = harness.createClient();
+
+    await expect(client.exec("reload")).resolves.toMatchObject({ stdout: "Reloading...\n" });
+    await expect(client.exec("greet", {}, { recoverable: false })).resolves.toMatchObject({
+      stdout: "hello\n",
+    });
+
+    expect(dispatchRequests(harness.requests)).toHaveLength(0);
+    expect(installRequests(harness.requests)).toHaveLength(0);
+  });
+
+  it("defaults custom transports to the direct path", async () => {
+    const harness = createDispatchHarness({ greet: () => "hello" });
+    const client = createObsidianClient({
+      transport: async (request) => {
+        harness.requests.push(request.argv);
+        return createExecResult(request.bin, request.argv, "hello\n");
+      },
+      vault: "test",
+    });
+
+    await expect(client.exec("greet")).resolves.toMatchObject({ stdout: "hello\n" });
+    expect(harness.requests).toEqual([["vault=test", "greet"]]);
+  });
+
+  it("falls back to the direct path on apps without window.handleCli", async () => {
+    const harness = createDispatchHarness({ greet: () => "hello" });
+    delete (globalThis as MutableGlobal).handleCli;
+    const client = harness.createClient();
+
+    await expect(client.exec("greet")).resolves.toMatchObject({ stdout: "hello\n" });
+    await expect(client.exec("greet")).resolves.toMatchObject({ stdout: "hello\n" });
+
+    expect(dispatchRequests(harness.requests)).toHaveLength(0);
+    // The unsupported answer is cached: one install probe, ever.
+    expect(installRequests(harness.requests)).toHaveLength(1);
+  });
+
+  it("carries dev.evalJson through the dispatch protocol end to end", async () => {
+    const harness = createDispatchHarness({
+      eval: (flags) => (0, eval)(flags.code ?? "") as string,
+    });
+    const client = harness.createClient();
+
+    await expect(client.dev.evalJson<{ items: number[] }>("({ items: [1, 2] })")).resolves.toEqual({
+      items: [1, 2],
+    });
+    expect(dispatchRequests(harness.requests)).toHaveLength(1);
+  });
+});
+
+describe("dispatch shim", () => {
+  it("refuses payloads pinned to another registry generation without dispatching", async () => {
+    let runs = 0;
+    createDispatchHarness({
+      "run-once": () => {
+        runs += 1;
+        return "ran";
+      },
+    });
+    (0, eval)(buildDispatchShimCode("gen-1"));
+    const handleCli = (globalThis as MutableGlobal).handleCli as (
+      argv: string[],
+    ) => Promise<string>;
+
+    const stale = await handleCli([
+      DISPATCH_COMMAND,
+      `payload=${JSON.stringify({ argv: ["run-once"], installId: "gen-0", nonce: "n1" })}`,
+    ]);
+
+    expect(JSON.parse(stale)).toEqual({ installId: "gen-1", state: "stale" });
+    expect(runs).toBe(0);
+  });
+
+  it("is idempotent: a second install returns the existing generation", () => {
+    createDispatchHarness({});
+    const first = (0, eval)(buildDispatchShimCode("gen-1")) as { installId: string };
+    const second = (0, eval)(buildDispatchShimCode("gen-2")) as { installId: string };
+
+    expect(first.installId).toBe("gen-1");
+    expect(second.installId).toBe("gen-1");
+  });
+
+  it("evicts only settled entries past the cap, never in-flight ones", async () => {
+    createDispatchHarness({
+      hang: () => new Promise(() => {}),
+      quick: () => "ok",
+    });
+    (0, eval)(buildDispatchShimCode("gen-1", 2));
+    const handleCli = (globalThis as MutableGlobal).handleCli as (
+      argv: string[],
+    ) => Promise<string>;
+    const dispatch = (nonce: string, command: string) =>
+      handleCli([
+        DISPATCH_COMMAND,
+        `payload=${JSON.stringify({ argv: [command], installId: "gen-1", nonce })}`,
+      ]);
+
+    void dispatch("pending-1", "hang");
+    await dispatch("done-1", "quick");
+    await dispatch("done-2", "quick");
+    await dispatch("done-3", "quick");
+
+    const ops = ((globalThis as MutableGlobal)[SHIM_GLOBAL] as { ops: Map<string, unknown> }).ops;
+    // Cap 2: the pending entry survives every eviction; the oldest done
+    // entries are reclaimed first.
+    expect(ops.has("pending-1")).toBe(true);
+    expect(ops.has("done-3")).toBe(true);
+    expect(ops.has("done-1")).toBe(false);
+  });
+});

--- a/tests/core/dispatch.test.ts
+++ b/tests/core/dispatch.test.ts
@@ -26,7 +26,13 @@ afterEach(() => {
   delete globals.window;
 });
 
-type RequestBehavior = "delay-request" | "drop-reply" | "fail-exit" | "timeout" | undefined;
+type RequestBehavior =
+  | "delay-request"
+  | "drop-reply"
+  | "fail-exit"
+  | "frame-disposed"
+  | "timeout"
+  | undefined;
 
 type CommandHandler = (flags: Record<string, string>) => unknown;
 
@@ -112,6 +118,17 @@ function createDispatchHarness(handlers: Record<string, CommandHandler>) {
       throw new ObsidianCommandTimeoutError(request.bin, request.argv, request.timeoutMs ?? 0);
     }
 
+    if (behavior === "frame-disposed") {
+      // The renderer tore down mid-request: the command may or may not have
+      // dispatched, and Obsidian's main process converts the rejected
+      // executeJavaScript into a served string reply at exit 0.
+      return createExecResult(
+        request.bin,
+        request.argv,
+        "Error: Render frame was disposed before WebFrameMain could be accessed\n",
+      );
+    }
+
     const served = serveThroughHandleCli(command, tokens);
 
     if (behavior === "drop-reply") {
@@ -138,6 +155,7 @@ function createDispatchHarness(handlers: Record<string, CommandHandler>) {
       const pending = delayed.splice(0);
       return Promise.all(pending.map((fire) => fire()));
     },
+    realHandleCli,
     requests,
     setBehavior: (next: (request: ExecuteRequest) => RequestBehavior) => {
       behaviorFor = next;
@@ -287,6 +305,60 @@ describe("runRecoverableExec via client.exec", () => {
     // The next exec() reinstalls the shim and works again.
     harness.setBehavior(() => undefined);
     await expect(client.exec("mutate")).resolves.toMatchObject({ stdout: "mutated\n" });
+    expect(installRequests(harness.requests)).toHaveLength(2);
+  });
+
+  it("never resends after a frame-disposal reply - the dispatch's fate is unknown", async () => {
+    let runs = 0;
+    const harness = createDispatchHarness({
+      "run-once": () => {
+        runs += 1;
+        return "ran";
+      },
+    });
+    harness.setBehavior((request) => {
+      if (request.argv[1] !== DISPATCH_COMMAND) {
+        return undefined;
+      }
+      // The context reset that produced the frame-disposal reply also wipes
+      // the shim registry.
+      delete (globalThis as MutableGlobal)[SHIM_GLOBAL];
+      return "frame-disposed";
+    });
+    const client = harness.createClient();
+
+    const error = await client.exec("run-once", {}, { timeoutMs: 2_000 }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ObsidianCommandDispatchError);
+    expect((error as ObsidianCommandDispatchError).reason).toBe("context-reset");
+    // The command was never re-dispatched into the fresh context.
+    expect(dispatchRequests(harness.requests)).toHaveLength(1);
+    expect(runs).toBe(0);
+  });
+
+  it("reinstalls and resends after the not-found reply that proves the command never ran", async () => {
+    let runs = 0;
+    const harness = createDispatchHarness({
+      "run-once": () => {
+        runs += 1;
+        return "ran";
+      },
+    });
+    const client = harness.createClient();
+
+    // Warm the shim, then simulate a renderer reload between calls: the shim
+    // global and the handleCli wrapper are gone, so the next dispatch hits
+    // Obsidian's real parser and gets the deterministic not-found reply.
+    await client.exec("run-once");
+    const globals = globalThis as MutableGlobal;
+    delete globals[SHIM_GLOBAL];
+    globals.handleCli = harness.realHandleCli;
+
+    await expect(client.exec("run-once")).resolves.toMatchObject({ stdout: "ran\n" });
+
+    expect(runs).toBe(2);
+    // First call: one dispatch. Second call: not-found probe + resend.
+    expect(dispatchRequests(harness.requests)).toHaveLength(3);
     expect(installRequests(harness.requests)).toHaveLength(2);
   });
 

--- a/tests/core/dispatch.test.ts
+++ b/tests/core/dispatch.test.ts
@@ -31,6 +31,7 @@ type RequestBehavior =
   | "drop-reply"
   | "fail-exit"
   | "frame-disposed"
+  | "hang"
   | "timeout"
   | undefined;
 
@@ -99,6 +100,10 @@ function createDispatchHarness(handlers: Record<string, CommandHandler>) {
 
     if (behavior === "timeout") {
       throw new ObsidianCommandTimeoutError(request.bin, request.argv, request.timeoutMs ?? 0);
+    }
+
+    if (behavior === "hang") {
+      return new Promise(() => {});
     }
 
     if (behavior === "fail-exit") {
@@ -451,6 +456,24 @@ describe("runRecoverableExec via client.exec", () => {
     expect(Date.now() - start).toBeLessThan(1_000);
   });
 
+  it("bounds waiting on a shared shim install by each caller's own deadline", async () => {
+    const harness = createDispatchHarness({ greet: () => "hello" });
+    harness.setBehavior((request) => (request.argv[1] === "eval" ? "hang" : undefined));
+    const client = harness.createClient();
+
+    // The first caller creates the (never-resolving) shared install.
+    const first = client.exec("greet", {}, { timeoutMs: 3_000 });
+    first.catch(() => {});
+
+    const start = Date.now();
+    const error = await client.exec("greet", {}, { timeoutMs: 300 }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ObsidianCommandDispatchError);
+    expect((error as ObsidianCommandDispatchError).reason).toBe("undelivered");
+    // The short-deadline caller did not inherit the shared install's budget.
+    expect(Date.now() - start).toBeLessThan(2_000);
+  });
+
   it("caps proof-gated resends with a precise undelivered failure", async () => {
     let runs = 0;
     const harness = createDispatchHarness({
@@ -568,31 +591,34 @@ describe("dispatch shim", () => {
     expect(second.installId).toBe("gen-1");
   });
 
-  it("evicts only settled entries past the cap, never in-flight ones", async () => {
+  it("evicts only settled entries whose TTL passed, never in-flight or live ones", async () => {
     createDispatchHarness({
       hang: () => new Promise(() => {}),
       quick: () => "ok",
     });
-    (0, eval)(buildDispatchShimCode("gen-1", 2));
+    (0, eval)(buildDispatchShimCode("gen-1"));
     const handleCli = (globalThis as MutableGlobal).handleCli as (
       argv: string[],
     ) => Promise<string>;
-    const dispatch = (nonce: string, command: string) =>
+    const dispatch = (nonce: string, command: string, ttlMs: number) =>
       handleCli([
         DISPATCH_COMMAND,
-        `payload=${JSON.stringify({ argv: [command], installId: "gen-1", nonce })}`,
+        `payload=${JSON.stringify({ argv: [command], installId: "gen-1", nonce, ttlMs })}`,
       ]);
 
-    void dispatch("pending-1", "hang");
-    await dispatch("done-1", "quick");
-    await dispatch("done-2", "quick");
-    await dispatch("done-3", "quick");
+    void dispatch("pending-expired", "hang", 1);
+    await dispatch("done-expired", "quick", 1);
+    await dispatch("done-live", "quick", 60_000);
+    await sleep(10);
+    // A new insert triggers the eviction scan.
+    await dispatch("fresh", "quick", 60_000);
 
     const ops = ((globalThis as MutableGlobal)[SHIM_GLOBAL] as { ops: Map<string, unknown> }).ops;
-    // Cap 2: the pending entry survives every eviction; the oldest done
-    // entries are reclaimed first.
-    expect(ops.has("pending-1")).toBe(true);
-    expect(ops.has("done-3")).toBe(true);
-    expect(ops.has("done-1")).toBe(false);
+    // Only the settled entry whose TTL passed is reclaimed; a pending entry is
+    // never evicted regardless of age, and live entries survive.
+    expect(ops.has("done-expired")).toBe(false);
+    expect(ops.has("pending-expired")).toBe(true);
+    expect(ops.has("done-live")).toBe(true);
+    expect(ops.has("fresh")).toBe(true);
   });
 });

--- a/tests/core/dispatch.test.ts
+++ b/tests/core/dispatch.test.ts
@@ -85,7 +85,8 @@ function createDispatchHarness(handlers: Record<string, CommandHandler>) {
     ) => Promise<unknown>;
     try {
       const value = (await handleCli([command, ...tokens])) as string | null | undefined;
-      return value == null ? "" : String(value);
+      // Mirrors main's `d && b(d)`: falsy resolutions write nothing.
+      return value ? String(value) : "";
     } catch (error) {
       return typeof error === "string" ? `Error: ${error}` : String(error);
     }
@@ -101,10 +102,10 @@ function createDispatchHarness(handlers: Record<string, CommandHandler>) {
     }
 
     if (behavior === "fail-exit") {
-      throw new ObsidianCommandError(
-        `Obsidian command failed with exit code 1: ${request.bin}`,
-        createExecResult(request.bin, request.argv, ""),
-      );
+      throw new ObsidianCommandError(`Obsidian command failed with exit code 1: ${request.bin}`, {
+        ...createExecResult(request.bin, request.argv, ""),
+        exitCode: 1,
+      });
     }
 
     if (command === "eval") {
@@ -208,6 +209,7 @@ describe("runRecoverableExec via client.exec", () => {
         throw "nope";
       },
       quiet: () => undefined,
+      zero: () => 0,
     });
     const client = harness.createClient();
 
@@ -220,6 +222,9 @@ describe("runRecoverableExec via client.exec", () => {
       stdout: "Error: kaboom\n",
     });
     await expect(client.exec("quiet")).resolves.toMatchObject({ exitCode: 0, stdout: "" });
+    // A falsy resolution writes nothing on the direct path (`d && b(d)` in
+    // Obsidian's main process) - the recovered path matches.
+    await expect(client.exec("zero")).resolves.toMatchObject({ exitCode: 0, stdout: "" });
     await expect(client.exec("no-such-command")).resolves.toMatchObject({
       exitCode: 0,
       stdout:
@@ -407,11 +412,72 @@ describe("runRecoverableExec via client.exec", () => {
     );
     const client = harness.createClient();
 
-    await expect(client.exec("anything", {}, { allowNonZeroExit: true })).resolves.toMatchObject({
-      exitCode: 0,
-      stdout: "",
-    });
+    const result = await client.exec("anything", { flag: "x" }, { allowNonZeroExit: true });
+    expect(result).toMatchObject({ exitCode: 1, stdout: "" });
+    // The outcome is reported against the caller's command, not the internal
+    // dispatch verb.
+    expect(result.argv).toEqual(["vault=test", "anything", "flag=x"]);
     await expect(client.exec("anything")).rejects.toBeInstanceOf(ObsidianCommandError);
+  });
+
+  it("keeps context-destroying palette ids on the direct path", async () => {
+    const harness = createDispatchHarness({
+      command: (flags) => `ran ${flags.id}`,
+    });
+    const client = harness.createClient();
+
+    await expect(client.exec("command", { id: "app:reload" })).resolves.toMatchObject({
+      stdout: "ran app:reload\n",
+    });
+    expect(dispatchRequests(harness.requests)).toHaveLength(0);
+
+    await expect(client.exec("command", { id: "quickadd:run" })).resolves.toMatchObject({
+      stdout: "ran quickadd:run\n",
+    });
+    expect(dispatchRequests(harness.requests)).toHaveLength(1);
+  });
+
+  it("propagates hard install failures immediately instead of retrying out the deadline", async () => {
+    const harness = createDispatchHarness({ greet: () => "hello" });
+    harness.setBehavior((request) => (request.argv[1] === "eval" ? "fail-exit" : undefined));
+    const client = harness.createClient();
+
+    const start = Date.now();
+    await expect(client.exec("greet", {}, { timeoutMs: 10_000 })).rejects.toBeInstanceOf(
+      ObsidianCommandError,
+    );
+    // A cold-app connect failure surfaces like the direct path does - fast -
+    // so waitFor probes keep their own cadence.
+    expect(Date.now() - start).toBeLessThan(1_000);
+  });
+
+  it("caps proof-gated resends with a precise undelivered failure", async () => {
+    let runs = 0;
+    const harness = createDispatchHarness({
+      "run-once": () => {
+        runs += 1;
+        return "ran";
+      },
+    });
+    // Before every dispatch attempt the renderer "reloads": the shim global
+    // vanishes and handleCli reverts, so each attempt gets the deterministic
+    // not-found reply, reinstalls, and resends - forever, without the cap.
+    harness.setBehavior((request) => {
+      if (request.argv[1] === DISPATCH_COMMAND) {
+        const globals = globalThis as MutableGlobal;
+        delete globals[SHIM_GLOBAL];
+        globals.handleCli = harness.realHandleCli;
+      }
+      return undefined;
+    });
+    const client = harness.createClient();
+
+    const error = await client.exec("run-once", {}, { timeoutMs: 30_000 }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ObsidianCommandDispatchError);
+    expect((error as ObsidianCommandDispatchError).reason).toBe("undelivered");
+    expect(runs).toBe(0);
+    expect(dispatchRequests(harness.requests).length).toBeLessThanOrEqual(8);
   });
 
   it("keeps context-destroying verbs and recoverable:false on the direct path", async () => {


### PR DESCRIPTION
Closes #25.

## Problem

`exec()` commands hang for the full 30s transport timeout when the Obsidian CLI's single-shot reply is lost, flaking consumer e2e suites on `plugin:reload`, `quickadd:run`, and - as this investigation showed - plain `dev.eval` too.

Root cause, pinned down against Obsidian 1.13.4 (decompiled `main.js`/`app.js` plus a recorder shim wrapped around `window.handleCli` during a reproduced failing run):

- Every CLI verb - core, plugin-registered, and `eval` itself - is relayed by the app's main process into the renderer via `webContents.executeJavaScript("window.handleCli(argv)")`; the resolved string is written to the socket and is the *only* carrier of the result.
- That bridge loses and delays messages in both directions under suite load, with **no renderer reload involved**. Captured in a failing run: `plugin:reload id=quickadd` dispatched and completed in-app in **11ms**, its reply never arrived, and the consumer's 15s hook timeout killed the suite; in the same trace an eval request was delayed **13.7s** before dispatching while neighboring commands were instant. A separate idle-instance probe saw a reply delayed >120s.
- Obsidian's CLI server has no timeout or retry around the bridge: a lost response leg leaves the socket open forever; the CLI client hangs until our transport kills it.

So the issue's framing was right (single-shot reply channel, same as #21/#22 for `evalJsonAsync`), with one correction: the loss mechanism is the executeJavaScript IPC itself, not renderer reloads - the recovery registry survives the observed failures, which is what makes recovery effective.

## Design: recoverable dispatch, not per-command modeling

The issue proposed extending the eval kickoff-and-poll to exec, modeling `plugin:reload` as in-app disable/enable, and blind-retrying "core read-only" commands. This PR ships something simpler and stronger - one mechanism for every verb:

- A **one-time shim** wraps `window.handleCli` in the renderer (installed via a short idempotent eval). Normal commands pass through untouched. The shim intercepts one synthetic verb, `__obsidian-e2e:dispatch payload=<json>`, whose payload carries the real command argv, a per-call **nonce**, and the shim **generation** (`installId`).
- The shim records `{state:'pending'}` under the nonce *before* dispatching, stores the final reply on settle (formatted byte-identically to Obsidian's main process), **dedups** repeated nonces (a delayed duplicate joins the original run), and **refuses** payloads pinned to another generation without dispatching.
- `exec()` sends one dispatch attempt on a 5s process budget. A lost reply is recovered by short idempotent registry polls; a resend happens only when it is provably safe: the registry shows no entry in the pinned generation, or Obsidian's own deterministic `Command "__obsidian-e2e:dispatch" not found` reply proves the inner command was never parsed. Any other non-envelope reply (e.g. the `Error: Render frame was disposed...` string the main process serves when a renderer teardown races a request) marks the attempt's fate unknown and forbids resending.

**Safety argument:** a command executes only inside the shim's dispatch branch, guarded by an atomic (single-threaded renderer) nonce check-and-set, and only for payloads pinned to the live generation. Resends reuse the same nonce within one generation and cross generations only when no attempt has unknown fate. Result: at-most-once unconditionally, exactly-once whenever the renderer context survives - the only case in which the command could run at all. `quickadd:run` cannot double-fire; unit tests replay the observed delayed-request interleaving and the frame-disposal reply to prove it.

Why this shape instead of the proposed one:

- Handlers see their **exact original argv** - no nonce flag injection (quickadd forwards unknown flags into template variables, so flag injection is semantically unsafe) and no re-modeled `plugin:reload` semantics to keep in sync with Obsidian.
- The happy path stays **one CLI roundtrip** (the eval-kickoff design costs 2-3 per command).
- Everything built on `exec()` gains recovery automatically: `dev.eval`/`dev.evalJson` (one of the two reproduced failures was a plain `dev.eval` hang), `command(id).run()`, `plugin(id).reload()`, and `evalJsonAsync`'s internal kickoff/polls.
- No idempotency classification to maintain; recovery correctness comes from the protocol, not per-command knowledge.

Failure states are typed: `ObsidianCommandDispatchError` with `reason` = `ambiguous-delivery` | `context-reset` | `still-pending` | `undelivered` (the last one provably-unexecuted, safe to retry).

## Scope and defaults

- Recoverable by default on the built-in transport. Custom `transport` implementations (test fakes) default to the direct path - the protocol only means anything against the real CLI - with `ExecOptions.recoverable` as the per-call/default override.
- `reload`, `restart`, `plugins:restrict`, `dev:mobile` always use the direct path (verified as the only CLI handlers that destroy the renderer context, which the registry lives in), as does the generic `command` verb with the context-destroying built-in ids `app:reload`/`app:quit`. Plugin commands with reload side effects cannot be enumerated; the README directs those through `recoverable: false`.
- On the recoverable path `timeoutMs` becomes the overall deadline for the result (was: single process budget); long-running commands no longer die with the 30s socket hold, since polls carry the result after the attempt process is killed.
- Apps without `window.handleCli` degrade gracefully to the exact legacy path (cached after one probe).

## Evidence

Baseline (obsidian-e2e 0.9.0, quickadd @ master, fresh-launch loop `stop → start → test:e2e`):

- Run 4 of 13: `conditional-branch-persistence` failed - a `dev.eval` inside a `waitFor` blocked ~30s (31.5s test vs 10s wait budget).
- Run 10 (instrumented): `scorecard-composed-flows` afterAll hook timeout - the recorder trace shows `plugin:reload` completed in-app in 11ms with the reply lost, plus the 13.7s delayed-request anomaly. Sentinel intact: no renderer reload.

With this branch linked into quickadd (`pnpm link`, since reverted): **18 consecutive fresh-launch full-suite runs, 49/49 tests green each, zero transport-timeout failures** (12 on the initial protocol, 3 after the frame-disposal amendment, 3 after the review-hardening commit). Several runs show the recovery signature - suite duration 25-36s instead of the ~20s baseline, i.e. loss events occurred and were absorbed (~5s attempt timeout + instant poll recovery) instead of failing tests. At the observed ~1-in-3 baseline failure rate, 18 clean runs by luck would be ≈0.2%.

Live protocol verification: after a suite run the in-app registry showed `{"installed":true,"ops":242}` - every command of the run served through the shim.

## Adversarial review

The design and diff went through four adversarial review passes (two on the design, two on the implementation, on both Claude and Codex). Outcomes:

- **Confirmed blocker, fixed and independently re-verified (e08002f):** a rejected `executeJavaScript` is *served as a string reply at exit 0* (e.g. `Error: Render frame was disposed...`), so a non-envelope reply must not be treated as proof of non-execution - the original branch would have resent and double-executed on reload-during-command. Now only the deterministic not-found reply for the dispatch verb authorizes a resend; anything else is unknown fate. A reviewer re-ran their double-execution repro against the fixed build: one execution, honest `context-reset`, and the zero-byte-reply variant is covered too.
- **Review amendments (1f697a9):** `command id=app:reload|app:quit` excluded from the recoverable path (the generic palette verb bypassed the verb-name exclusion list); hard install failures (cold-app connect refused) propagate immediately instead of retrying out the exec deadline (preserves `waitFor` probe cadence during fresh launches); resends are capped (8, proof-gated, precise `undelivered`) and paced; `allowNonZeroExit` outcomes report the caller's argv instead of the internal dispatch verb's; falsy handler replies match the direct path byte-for-byte (`d && b(d)` writes nothing); `evalJsonAsync`'s poll/cleanup reads ride the direct path so two recovery protocols never stack (its kickoff keeps recoverable dispatch, which strengthens delivery without touching exactly-once); docs attribute the guarantee to proof-gated resends, its actual mechanism.
- **Reviewer-verified sound:** the single-threaded check-and-set dedup, generation pinning, install idempotency (a reinstall returns the existing generation), pending-entry eviction immunity, and the pending-before-dispatch ordering that makes `missing` unobservable for a command already running.
- **Accepted as follow-ups** (all reviewers classed these non-blocking): tombstone-based eviction so `missing` can never mean "evicted" even past 2000 completed dispatches within one recovery window; exponential poll backoff; an in-app grace period to cut recovery latency below the 5s attempt budget; `ObsidianCommandDispatchError` not extending `ObsidianCommandTimeoutError` (documented in the changeset instead).

## Notes

- Package unit tests: 280 passing, incl. 17 protocol tests with an in-process emulator that executes the real generated shim/install/poll code and replays the observed loss modes.
- The upstream fix belongs in Obsidian (timeout/retry around the CLI server's executeJavaScript); worth reporting, but consumers need this package to work against today's app.
- `evalJsonAsync` keeps its protocol; its internal commands ride recoverable exec and get stronger delivery with unchanged semantics. A follow-up could simplify it atop recoverable exec.
